### PR TITLE
Change domain whitelist to domain whitelisting

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -22,7 +22,7 @@
     * [Persistent Menu](#persistent-menu)
     * [Get Started Button](#get-started-button)
     * [Greeting Text](#greeting-text)
-    * [Domain Whitelist](#domain-whitelist)
+    * [Domain Whitelisting](#domain-whitelisting)
     * [Account Linking URL](#account-linking-url)
     * [Payment Settings](#payment-settings)
     * [Target Audience](#target-audience)
@@ -1537,15 +1537,15 @@ client.deleteGreetingText();
 
 <a id="domain-whitelist" />
 
-### Domain Whitelist - [Official Docs](https://developers.facebook.com/docs/messenger-platform/messenger-profile/domain-whitelisting)
+### Domain Whitelisting - [Official Docs](https://developers.facebook.com/docs/messenger-platform/messenger-profile/domain-whitelisting)
 
-## `getDomainWhitelist`
+## `getDomainWhitelisting`
 
-Retrieves the current value of domain whitelist.
+Retrieves the current value of domain whitelisting.
 
 Example:
 ```js
-client.getDomainWhitelist().then(domains => {
+client.getDomainWhitelisting().then(domains => {
   console.log(domains);
   // ['http://www.example.com/']
 });
@@ -1553,9 +1553,9 @@ client.getDomainWhitelist().then(domains => {
 
 <br />
 
-## `setDomainWhitelist(domains)`
+## `setDomainWhitelisting(domains)`
 
-Sets the values of domain whitelist.
+Sets the values of domain whitelisting.
 
 Param   | Type            | Description
 ------- | --------------- | -----------
@@ -1563,18 +1563,18 @@ domains | `Array<String>` | Array of [whitelisted_domain](https://developers.fac
 
 Example:
 ```js
-client.setDomainWhitelist(['www.example.com']);
+client.setDomainWhitelisting(['www.example.com']);
 ```
 
 <br />
 
-## `deleteDomainWhitelist`
+## `deleteDomainWhitelisting`
 
-Deletes domain whitelist.
+Deletes domain whitelisting.
 
 Example:
 ```js
-client.deleteDomainWhitelist();
+client.deleteDomainWhitelisting();
 ```
 
 <a id="account-linking-url" />

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -200,23 +200,23 @@ export default class MessengerClient {
     this.deleteMessengerProfile(['greeting']);
 
   /**
-   * Domain Whitelist
+   * Domain Whitelisting
    *
    * https://developers.facebook.com/docs/messenger-platform/messenger-profile/domain-whitelisting
    */
-  getDomainWhitelist = (): Promise<MessengerProfileResponse> =>
+  getDomainWhitelisting = (): Promise<MessengerProfileResponse> =>
     this.getMessengerProfile(['whitelisted_domains']).then(
       res => res[0].whitelisted_domains
     );
 
-  setDomainWhitelist = (
+  setDomainWhitelisting = (
     domains: Array<string>
   ): Promise<MutationSuccessResponse> =>
     this.setMessengerProfile({
       whitelisted_domains: domains,
     });
 
-  deleteDomainWhitelist = (): Promise<MutationSuccessResponse> =>
+  deleteDomainWhitelisting = (): Promise<MutationSuccessResponse> =>
     this.deleteMessengerProfile(['whitelisted_domains']);
 
   /**

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
@@ -829,9 +829,9 @@ describe('greeting text', () => {
   });
 });
 
-describe('domain whitelist', () => {
-  describe('#getDomainWhitelist', () => {
-    it('should response data of domain whitelist', async () => {
+describe('domain whitelisting', () => {
+  describe('#getDomainWhitelisting', () => {
+    it('should response data of domain whitelisting', async () => {
       const { client, mock } = createMock();
 
       const reply = {
@@ -848,13 +848,13 @@ describe('domain whitelist', () => {
         )
         .reply(200, reply);
 
-      const res = await client.getDomainWhitelist();
+      const res = await client.getDomainWhitelisting();
 
       expect(res).toEqual(['http://www.yoctol.com/']);
     });
   });
 
-  describe('#setDomainWhitelist', () => {
+  describe('#setDomainWhitelisting', () => {
     it('should response success result', async () => {
       const { client, mock } = createMock();
 
@@ -868,13 +868,13 @@ describe('domain whitelist', () => {
         })
         .reply(200, reply);
 
-      const res = await client.setDomainWhitelist(['www.yoctol.com']);
+      const res = await client.setDomainWhitelisting(['www.yoctol.com']);
 
       expect(res).toEqual(reply);
     });
   });
 
-  describe('#deleteDomainWhitelist', () => {
+  describe('#deleteDomainWhitelisting', () => {
     it('should response success result', async () => {
       const { client, mock } = createMock();
 
@@ -888,7 +888,7 @@ describe('domain whitelist', () => {
         })
         .reply(200, reply);
 
-      const res = await client.deleteDomainWhitelist();
+      const res = await client.deleteDomainWhitelisting();
 
       expect(res).toEqual(reply);
     });


### PR DESCRIPTION
To match Messenger official API naming.
This is a breaking change.

https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/domain-whitelisting