### PR TITLE
implement passThreadControlToPageInbox

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -1857,6 +1857,22 @@ client.passThreadControl(USER_ID, APP_ID, 'free formed text for another app');
 
 <br />
 
+## `passThreadControlToPageInbox(userId, metadata)` - [Official Docs](https://developers.facebook.com/docs/messenger-platform/handover-protocol/pass-thread-control#page_inbox)
+
+Passes thread control from your app to "Page Inbox" app.
+
+Param       | Type     | Description
+----------- | ---------| -----------
+userId      | `String` | The PSID of the message recipient.
+metadata    | `String` | Metadata passed to the receiving app in the `pass_thread_control` webhook event.
+
+Example:
+```js
+client.passThreadControlToPageInbox(USER_ID, 'free formed text for another app');
+```
+
+<br />
+
 ## `takeThreadControl(userId, metadata)` - [Official Docs](https://developers.facebook.com/docs/messenger-platform/take-thread-control)
 
 Takes control of a specific thread from a Secondary Receiver app.

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -959,6 +959,9 @@ export default class MessengerClient {
       })
       .then(res => res.data, handleError);
 
+  passThreadControlToPageInbox = (recipientId: string, metadata?: string) =>
+    this.passThreadControl(recipientId, 263902037430900, metadata);
+
   /**
    * Take Thread Control
    *

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
@@ -3885,6 +3885,33 @@ describe('Handover Protocol API', () => {
     });
   });
 
+  describe('#passThreadControlToPageInbox', () => {
+    it('should call messages api to pass thread control to page inbox', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {
+        success: true,
+      };
+
+      mock
+        .onPost(`/me/pass_thread_control?access_token=${ACCESS_TOKEN}`, {
+          recipient: {
+            id: RECIPIENT_ID,
+          },
+          target_app_id: 263902037430900,
+          metadata: 'free formed text for another app',
+        })
+        .reply(200, reply);
+
+      const res = await client.passThreadControlToPageInbox(
+        RECIPIENT_ID,
+        'free formed text for another app'
+      );
+
+      expect(res).toEqual(reply);
+    });
+  });
+
   describe('#takeThreadControl', () => {
     it('should call messages api to take thread control', async () => {
       const { client, mock } = createMock();


### PR DESCRIPTION
https://developers.facebook.com/docs/messenger-platform/handover-protocol/pass-thread-control#page_inbox

This sets target_app_id to 263902037430900.