### PR TITLE
[messenger] implement getPageInfo

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -36,6 +36,7 @@
   * [Page Messaging Insights API](#page-messaging-insights-api)
   * [Built-in NLP API](#built-in-nlp-api)
   * [Event Logging API](#event-logging-api)
+  * [Others](#others)
 
 ## Installation
 
@@ -2638,6 +2639,25 @@ client.logCustomEvents({
       _fb_currency: 'USD',
     },
   ],
+});
+```
+
+<br />
+
+### Others
+
+## `getPageInfo`
+
+Get page name and page id using Graph API.
+
+Example:
+```js
+client.getPageInfo().then(page => {
+  console.log(page);
+  // {
+  //   name: 'Bot Demo',
+  //   id: '1895382890692546',
+  // }
 });
 ```
 

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -44,6 +44,7 @@ import type {
   MessengerNLPConfig,
   InsightMetric,
   InsightOptions,
+  PageInfo,
 } from './MessengerTypes';
 
 type Axios = {
@@ -102,6 +103,17 @@ export default class MessengerClient {
     );
     return this._axios;
   };
+
+  /**
+   * Get Page Info
+   *
+   * https://developers.facebook.com/docs/graph-api/using-graph-api
+   * id, name
+   */
+  getPageInfo = (): Promise<PageInfo> =>
+    this._axios
+      .get(`/me?access_token=${this._accessToken}`)
+      .then(res => res.data, handleError);
 
   /**
    * Get User Profile

--- a/packages/messaging-api-messenger/src/MessengerTypes.js
+++ b/packages/messaging-api-messenger/src/MessengerTypes.js
@@ -340,3 +340,8 @@ export type MessengerNLPConfig = {
   verbose?: boolean,
   n_best?: number,
 };
+
+export type PageInfo = {
+  name: string,
+  id: string,
+};

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
@@ -103,6 +103,24 @@ describe('#axios', () => {
   });
 });
 
+describe('page info', () => {
+  describe('#getPageInfo', () => {
+    it('should response page info', async () => {
+      const { client, mock } = createMock();
+      const reply = {
+        name: 'Bot Demo',
+        id: '1895382890692546',
+      };
+
+      mock.onGet(`/me?access_token=${ACCESS_TOKEN}`).reply(200, reply);
+
+      const res = await client.getPageInfo();
+
+      expect(res).toEqual(reply);
+    });
+  });
+});
+
 describe('user profile', () => {
   describe('#getUserProfile', () => {
     it('should response user profile', async () => {


### PR DESCRIPTION
## `getPageInfo`

Get page name and page id using Graph API.

Example:
```js
client.getPageInfo().then(page => {
  console.log(page);
  // {
  //   name: 'Bot Demo',
  //   id: '1895382890692546',
  // }
});
```

Close #212