### PR TITLE
Add sendMediaGroup in Telegram

### DIFF
--- a/packages/messaging-api-telegram/README.md
+++ b/packages/messaging-api-telegram/README.md
@@ -231,6 +231,25 @@ client.sendVoice(CHAT_ID, 'https://example.com/voice.ogg', {
 
 <br />
 
+## `sendMediaGroup(chatId, media [, options])` - [Official Docs](https://core.telegram.org/bots/api/#sendmediagroup)
+
+send a group of photos or videos as an album.
+
+Param   |  Type                             | Description
+------- | --------------------------------- | -----------
+chatId  | <code>Number &#124; String</code> | Unique identifier for the target chat or username of the target channel.
+media   | Array<[InputMedia](https://core.telegram.org/bots/api#inputmedia)> | A JSON-serialized array describing photos and videos to be sent, must include 2–10 items
+options | `Object`                          | Other optional parameters.
+
+Example:
+```js
+client.sendMediaGroup(CHAT_ID, [
+  { type: 'photo', media: 'BQADBAADApYAAgcZZAfj2-xeidueWwI' },
+]);
+```
+
+<br />
+
 ## `sendLocation(chatId, location [, options])` - [Official Docs](https://core.telegram.org/bots/api/#sendlocation)
 
 Sends point on the map.

--- a/packages/messaging-api-telegram/src/TelegramClient.js
+++ b/packages/messaging-api-telegram/src/TelegramClient.js
@@ -209,6 +209,16 @@ export default class TelegramClient {
   //   });
 
   /**
+   * https://core.telegram.org/bots/api#sendmediagroup
+   */
+  sendMediaGroup = (chatId: string, media: Array<Object>, options?: Object) =>
+    this._request('/sendMediaGroup', {
+      chat_id: chatId,
+      media,
+      ...options,
+    });
+
+  /**
    * https://core.telegram.org/bots/api#sendlocation
    */
   sendLocation = (

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.js
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.js
@@ -776,6 +776,50 @@ describe('send api', () => {
     });
   });
 
+  describe('#sendMediaGroup', () => {
+    it('should send a group of photos or videos as an album', async () => {
+      const { client, mock } = createMock();
+      const reply = {
+        ok: true,
+        result: {
+          message_id: 1,
+          from: {
+            id: 313534466,
+            first_name: 'first',
+            username: 'a_bot',
+          },
+          chat: {
+            id: 427770117,
+            first_name: 'first',
+            last_name: 'last',
+            type: 'private',
+          },
+          date: 1499403678,
+          photo: [
+            {
+              file_id: 'BQADBAADApYAAgcZZAfj2-xeidueWwI',
+              width: 1000,
+              height: 1000,
+            },
+          ],
+        },
+      };
+
+      mock
+        .onPost('/sendMediaGroup', {
+          chat_id: 427770117,
+          media: [{ type: 'photo', media: 'BQADBAADApYAAgcZZAfj2-xeidueWwI' }],
+        })
+        .reply(200, reply);
+
+      const res = await client.sendMediaGroup(427770117, [
+        { type: 'photo', media: 'BQADBAADApYAAgcZZAfj2-xeidueWwI' },
+      ]);
+
+      expect(res).toEqual(reply);
+    });
+  });
+
   describe('#sendLocation', () => {
     it('should send location message to user', async () => {
       const { client, mock } = createMock();


### PR DESCRIPTION
Add new method `sendMediaGroup`
It was added in [Telegram Bot API 3.5](https://core.telegram.org/bots/api#november-17-2017)