### PR TITLE
rename Messenger to MessengerBatch

### DIFF
--- a/packages/messaging-api-messenger/src/Messenger.js
+++ b/packages/messaging-api-messenger/src/Messenger.js
@@ -1,52 +1,29 @@
-/* @flow */
+import warning from 'warning';
 
-import type {
-  UserID,
-  Recipient,
-  SendOption,
-  Message,
-  BatchItem,
-} from './MessengerTypes';
+import MessengerBatch from './MessengerBatch';
 
-function createRequest(body: Object): BatchItem {
-  return {
-    method: 'POST',
-    relative_url: 'me/messages',
-    body,
-  };
+function createRequest(...args) {
+  warning(
+    false,
+    '`Messenger.createRequest` will breaking and become part of message creation API in v0.7. For batch usage, use `MessengerBatch.createRequest` instead.'
+  );
+  return MessengerBatch.createRequest(...args);
 }
 
-function createMessage(
-  idOrRecipient: UserID | Recipient,
-  message: Message,
-  options?: SendOption = {}
-): BatchItem {
-  const recipient =
-    typeof idOrRecipient === 'string'
-      ? {
-          id: idOrRecipient,
-        }
-      : idOrRecipient;
-  let messageType = 'UPDATE';
-  if (options.messaging_type) {
-    messageType = options.messaging_type;
-  } else if (options.tag) {
-    messageType = 'MESSAGE_TAG';
-  }
-  return createRequest({
-    messaging_type: messageType,
-    recipient,
-    message,
-    ...options,
-  });
+function createMessage(...args) {
+  warning(
+    false,
+    '`Messenger.createMessage` will breaking and become part of message creation API in v0.7. For batch usage, use `MessengerBatch.createMessage` instead.'
+  );
+  return MessengerBatch.createMessage(...args);
 }
 
-function createText(
-  recipient: UserID | Recipient,
-  text: string,
-  options?: SendOption
-): BatchItem {
-  return createMessage(recipient, { text }, options);
+function createText(...args) {
+  warning(
+    false,
+    '`Messenger.createText` will breaking and become part of message creation API in v0.7. For batch usage, use `MessengerBatch.createText` instead.'
+  );
+  return MessengerBatch.createText(...args);
 }
 
 const Messenger = {

--- a/packages/messaging-api-messenger/src/MessengerBatch.js
+++ b/packages/messaging-api-messenger/src/MessengerBatch.js
@@ -1,0 +1,58 @@
+/* @flow */
+
+import type {
+  UserID,
+  Recipient,
+  SendOption,
+  Message,
+  BatchItem,
+} from './MessengerTypes';
+
+function createRequest(body: Object): BatchItem {
+  return {
+    method: 'POST',
+    relative_url: 'me/messages',
+    body,
+  };
+}
+
+function createMessage(
+  idOrRecipient: UserID | Recipient,
+  message: Message,
+  options?: SendOption = {}
+): BatchItem {
+  const recipient =
+    typeof idOrRecipient === 'string'
+      ? {
+          id: idOrRecipient,
+        }
+      : idOrRecipient;
+  let messageType = 'UPDATE';
+  if (options.messaging_type) {
+    messageType = options.messaging_type;
+  } else if (options.tag) {
+    messageType = 'MESSAGE_TAG';
+  }
+  return createRequest({
+    messaging_type: messageType,
+    recipient,
+    message,
+    ...options,
+  });
+}
+
+function createText(
+  recipient: UserID | Recipient,
+  text: string,
+  options?: SendOption
+): BatchItem {
+  return createMessage(recipient, { text }, options);
+}
+
+const MessengerBatch = {
+  createRequest,
+  createMessage,
+  createText,
+};
+
+export default MessengerBatch;

--- a/packages/messaging-api-messenger/src/index.js
+++ b/packages/messaging-api-messenger/src/index.js
@@ -1,9 +1,11 @@
 /* @flow */
 
 import Messenger from './Messenger';
+import MessengerBatch from './MessengerBatch';
 import MessengerClient from './MessengerClient';
 
 module.exports = {
   Messenger,
+  MessengerBatch,
   MessengerClient,
 };


### PR DESCRIPTION
```js
MessengerBatch.createText(RECIPIENT_ID, 'Hello')
/* {
      method: 'POST',
      relative_url: 'me/messages',
      body: {
        messaging_type: 'UPDATE',
        message: {
          text: 'Hello',
        },
        recipient: {
          id: RECIPIENT_ID,
        },
      },
    }
*/
````

```js
Messenger.createText(RECIPIENT_ID, 'Hello')
```
Will be something like below in v0.7:

```js
    {
        messaging_type: 'UPDATE',
        message: {
          text: 'Hello',
        },
        recipient: {
          id: RECIPIENT_ID,
        },
    },
```