### PR TITLE
use only app access_token in createSubscribtion api

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -2860,6 +2860,7 @@ Create new Webhooks subscriptions.
 Param          | Type            | Description
 -------------- | --------------- | -----------
 app_id         | `String`        | ID of the app.
+access_token   | `String`        | App access token.
 callback_url   | `String`        | The URL that will receive the POST request when an update is triggered, and a GET request when attempting this publish operation.
 verify_token   | `String`        | An arbitrary string that can be used to confirm to your server that the request is valid.
 fields         | `Array<String>` | One or more of the set of valid fields in this object to subscribe to.
@@ -2870,6 +2871,19 @@ Example:
 ```js
 client.createSubscription({
   app_id: APP_ID,
+  access_token: APP_ACCESS_TOKEN,
+  callback_url: 'https://mycallback.com',
+  fields: ['messages', 'messaging_postbacks', 'messaging_referrals'],
+  verify_token: VERIFY_TOKEN,
+});
+```
+
+Or provide app id and app secret instead of app access token:
+
+```js
+client.createSubscription({
+  app_id: APP_ID,
+  access_token: `${APP_ID}|${APP_SECRET}`,
   callback_url: 'https://mycallback.com',
   fields: ['messages', 'messaging_postbacks', 'messaging_referrals'],
   verify_token: VERIFY_TOKEN,

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -160,7 +160,7 @@ export default class MessengerClient {
     ],
     include_values,
     verify_token,
-    access_token: customAccessToken,
+    access_token: appAccessToken,
   }: {
     app_id: string,
     object?: 'user' | 'page' | 'permissions' | 'payments',
@@ -168,20 +168,16 @@ export default class MessengerClient {
     fields?: Array<string>,
     include_values?: boolean,
     verify_token: string,
-    access_token?: string,
+    access_token: string,
   }): Promise<{ success: boolean }> =>
     this._axios
-      .post(
-        `/${appId}/subscriptions?access_token=${customAccessToken ||
-          this._accessToken}`,
-        {
-          object,
-          callback_url,
-          fields: fields.join(','),
-          include_values,
-          verify_token,
-        }
-      )
+      .post(`/${appId}/subscriptions?access_token=${appAccessToken}`, {
+        object,
+        callback_url,
+        fields: fields.join(','),
+        include_values,
+        verify_token,
+      })
       .then(res => res.data, handleError);
 
   /**

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
@@ -119,6 +119,8 @@ describe('page info', () => {
 });
 
 describe('subscription', () => {
+  const APP_ACCESS_TOKEN = 'APP_ACCESS_TOKEN';
+
   describe('#createSubscription', () => {
     it('should set default fields', async () => {
       const { client, mock } = createMock();
@@ -127,7 +129,7 @@ describe('subscription', () => {
       };
 
       mock
-        .onPost(`/54321/subscriptions?access_token=${ACCESS_TOKEN}`, {
+        .onPost(`/54321/subscriptions?access_token=${APP_ACCESS_TOKEN}`, {
           object: 'page',
           callback_url: 'https://mycallback.com',
           fields:
@@ -140,6 +142,7 @@ describe('subscription', () => {
         app_id: '54321',
         callback_url: 'https://mycallback.com',
         verify_token: '1234567890',
+        access_token: APP_ACCESS_TOKEN,
       });
 
       expect(res).toEqual(reply);
@@ -152,7 +155,7 @@ describe('subscription', () => {
       };
 
       mock
-        .onPost(`/54321/subscriptions?access_token=${ACCESS_TOKEN}`, {
+        .onPost(`/54321/subscriptions?access_token=${APP_ACCESS_TOKEN}`, {
           object: 'user',
           callback_url: 'https://mycallback.com',
           fields: 'messages,messaging_postbacks',
@@ -168,6 +171,7 @@ describe('subscription', () => {
         object: 'user',
         fields: ['messages', 'messaging_postbacks'],
         include_values: true,
+        access_token: APP_ACCESS_TOKEN,
       });
 
       expect(res).toEqual(reply);


### PR DESCRIPTION
This API relies on app access_token, not page access_token, so we should always pass `access_token` parameter.