### PR TITLE
Fix broadcast reach estimations

### DIFF
--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -1303,7 +1303,7 @@ export default class MessengerClient {
     { access_token: customAccessToken }: { access_token?: string } = {}
   ) =>
     this._axios
-      .post(
+      .get(
         `/${reachEstimationId}?access_token=${customAccessToken ||
           this._accessToken}`
       )

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -160,9 +160,9 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/graph-api/using-graph-api
    * id, name
    */
-  getPageInfo = (
-    { access_token: customAccessToken }: { access_token?: string } = {}
-  ): Promise<PageInfo> =>
+  getPageInfo = ({
+    access_token: customAccessToken,
+  }: { access_token?: string } = {}): Promise<PageInfo> =>
     this._axios
       .get(`/me?access_token=${customAccessToken || this._accessToken}`)
       .then(res => res.data, handleError);
@@ -576,9 +576,9 @@ export default class MessengerClient {
    *
    * https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags
    */
-  getMessageTags = (
-    { access_token: customAccessToken }: { access_token?: string } = {}
-  ): Promise<MessageTagResponse> =>
+  getMessageTags = ({
+    access_token: customAccessToken,
+  }: { access_token?: string } = {}): Promise<MessageTagResponse> =>
     this._axios
       .get(
         `/page_message_tags?access_token=${customAccessToken ||
@@ -1141,8 +1141,9 @@ export default class MessengerClient {
   sendSponsoredMessage = (adAccountId: string, message: Object) =>
     this._axios
       .post(
-        `/act_${adAccountId}/sponsored_message_ads?access_token=${this
-          ._accessToken}`,
+        `/act_${adAccountId}/sponsored_message_ads?access_token=${
+          this._accessToken
+        }`,
         message
       )
       .then(res => res.data, handleError);
@@ -1284,7 +1285,7 @@ export default class MessengerClient {
   ) =>
     this._axios
       .post(
-        `/broadcast_reach_estimations?access_token=${customAccessToken ||
+        `/me/broadcast_reach_estimations?access_token=${customAccessToken ||
           this._accessToken}`,
         {
           custom_label_id: customLabelId,
@@ -1469,9 +1470,9 @@ export default class MessengerClient {
    *
    * https://developers.facebook.com/docs/messenger-platform/reference/handover-protocol/secondary-receivers
    */
-  getSecondaryReceivers = (
-    { access_token: customAccessToken }: { access_token: ?string } = {}
-  ) =>
+  getSecondaryReceivers = ({
+    access_token: customAccessToken,
+  }: { access_token: ?string } = {}) =>
     this._axios
       .get(
         `/me/secondary_receivers?fields=id,name&access_token=${customAccessToken ||

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -160,9 +160,9 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/graph-api/using-graph-api
    * id, name
    */
-  getPageInfo = ({
-    access_token: customAccessToken,
-  }: { access_token?: string } = {}): Promise<PageInfo> =>
+  getPageInfo = (
+    { access_token: customAccessToken }: { access_token?: string } = {}
+  ): Promise<PageInfo> =>
     this._axios
       .get(`/me?access_token=${customAccessToken || this._accessToken}`)
       .then(res => res.data, handleError);
@@ -576,9 +576,9 @@ export default class MessengerClient {
    *
    * https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags
    */
-  getMessageTags = ({
-    access_token: customAccessToken,
-  }: { access_token?: string } = {}): Promise<MessageTagResponse> =>
+  getMessageTags = (
+    { access_token: customAccessToken }: { access_token?: string } = {}
+  ): Promise<MessageTagResponse> =>
     this._axios
       .get(
         `/page_message_tags?access_token=${customAccessToken ||
@@ -1141,9 +1141,8 @@ export default class MessengerClient {
   sendSponsoredMessage = (adAccountId: string, message: Object) =>
     this._axios
       .post(
-        `/act_${adAccountId}/sponsored_message_ads?access_token=${
-          this._accessToken
-        }`,
+        `/act_${adAccountId}/sponsored_message_ads?access_token=${this
+          ._accessToken}`,
         message
       )
       .then(res => res.data, handleError);
@@ -1470,9 +1469,9 @@ export default class MessengerClient {
    *
    * https://developers.facebook.com/docs/messenger-platform/reference/handover-protocol/secondary-receivers
    */
-  getSecondaryReceivers = ({
-    access_token: customAccessToken,
-  }: { access_token: ?string } = {}) =>
+  getSecondaryReceivers = (
+    { access_token: customAccessToken }: { access_token: ?string } = {}
+  ) =>
     this._axios
       .get(
         `/me/secondary_receivers?fields=id,name&access_token=${customAccessToken ||

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
@@ -4253,9 +4253,12 @@ describe('broadcast api', () => {
       };
 
       mock
-        .onPost(`/broadcast_reach_estimations?access_token=${ACCESS_TOKEN}`, {
-          custom_label_id: 938461089,
-        })
+        .onPost(
+          `/me/broadcast_reach_estimations?access_token=${ACCESS_TOKEN}`,
+          {
+            custom_label_id: 938461089,
+          }
+        )
         .reply(200, reply);
 
       const res = await client.startReachEstimation(938461089);

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
@@ -4276,9 +4276,7 @@ describe('broadcast api', () => {
         id: '<REACH_ESTIMATION_ID>',
       };
 
-      mock
-        .onPost(`/73450120243?access_token=${ACCESS_TOKEN}`)
-        .reply(200, reply);
+      mock.onGet(`/73450120243?access_token=${ACCESS_TOKEN}`).reply(200, reply);
 
       const res = await client.getReachEstimate(73450120243);
 


### PR DESCRIPTION
[fix] broadcast reach estimations path
[fix] broadcast get reach estimate method

https://developers.facebook.com/docs/messenger-platform/send-messages/broadcast-messages/estimate-reach