### PR TITLE
[0.7 Breaking Change] Messenger Insights API: resolve obj instead of [obj]

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -2604,7 +2604,6 @@ Example:
 ```js
 client.getDailyUniqueActiveThreadCounts().then(counts => {
   console.log(counts);
-  // [
   //   {
   //     "name": "page_messages_active_threads_unique",
   //     "period": "day",
@@ -2626,7 +2625,6 @@ client.getDailyUniqueActiveThreadCounts().then(counts => {
   //    "description": "Daily: total unique active threads created between users and page.",
   //    "id": "1234567/insights/page_messages_active_threads_unique/day"
   //   }
-  // ]
 });
 ```
 
@@ -2647,7 +2645,6 @@ Example:
 ```js
 client.getBlockedConversations().then(counts => {
   console.log(counts);
-  // [
   //   {
   //     "name": "page_messages_blocked_conversations_unique",
   //     "period": "day",
@@ -2662,7 +2659,6 @@ client.getBlockedConversations().then(counts => {
   //       }
   //    ]
   //   }
-  // ]
 });
 ```
 
@@ -2683,7 +2679,6 @@ Example:
 ```js
 client.getReportedConversations().then(counts => {
   console.log(counts);
-  // [
   //   {
   //     "name": "page_messages_reported_conversations_unique",
   //     "period": "day",
@@ -2698,7 +2693,6 @@ client.getReportedConversations().then(counts => {
   //       }
   //     ]
   //   }
-  // ]
 });
 ```
 
@@ -2719,7 +2713,6 @@ Example:
 ```js
 client.getReportedConversationsByReportType().then(counts => {
   console.log(counts);
-  // [
   //   {
   //     name: 'page_messages_reported_conversations_by_report_type_unique',
   //     period: 'day',
@@ -2742,7 +2735,6 @@ client.getReportedConversationsByReportType().then(counts => {
   //       },
   //     ],
   //   },
-  // ];
 });
 ```
 
@@ -2768,7 +2760,6 @@ Example:
 ```js
 client.getDailyUniqueConversationCounts().then(counts => {
   console.log(counts);
-  // [
   //   {
   //     "name": "page_messages_feedback_by_action_unique",
   //     "period": "day",
@@ -2798,7 +2789,6 @@ client.getDailyUniqueConversationCounts().then(counts => {
   //     "description": "Daily: total unique active threads created between users and page.",
   //     "id": "1234567/insights/page_messages_active_threads_unique/day"
   //   }
-  // ],
 });
 ```
 

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -1441,26 +1441,36 @@ export default class MessengerClient {
       .then(res => res.data.data, handleError);
 
   getDailyUniqueActiveThreadCounts = (options?: Object = {}) =>
-    this.getInsights(['page_messages_active_threads_unique'], options);
+    this.getInsights(['page_messages_active_threads_unique'], options).then(
+      result => result[0]
+    );
 
   getBlockedConversations = (options?: Object = {}) =>
-    this.getInsights(['page_messages_blocked_conversations_unique'], options);
+    this.getInsights(
+      ['page_messages_blocked_conversations_unique'],
+      options
+    ).then(result => result[0]);
 
   getReportedConversations = (options?: Object = {}) =>
-    this.getInsights(['page_messages_reported_conversations_unique'], options);
+    this.getInsights(
+      ['page_messages_reported_conversations_unique'],
+      options
+    ).then(result => result[0]);
 
   getReportedConversationsByReportType = (options?: Object = {}) =>
     this.getInsights(
       ['page_messages_reported_conversations_by_report_type_unique'],
       options
-    );
+    ).then(result => result[0]);
 
   getDailyUniqueConversationCounts = () => {
     warning(
       false,
       'page_messages_feedback_by_action_unique is deprecated as of November 7, 2017.\nThis metric will be removed in Graph API v2.12.'
     );
-    return this.getInsights(['page_messages_feedback_by_action_unique']);
+    return this.getInsights(['page_messages_feedback_by_action_unique']).then(
+      result => result[0]
+    );
   };
 
   /**

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-insights.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-insights.spec.js
@@ -127,31 +127,28 @@ describe('Page Messaging Insights API', () => {
 
       const res = await client.getDailyUniqueActiveThreadCounts();
 
-      expect(res).toEqual([
-        {
-          name: 'page_messages_active_threads_unique',
-          period: 'day',
-          values: [
-            {
-              value: 83111,
-              end_time: '2017-02-02T08:00:00+0000',
-            },
-            {
-              value: 85215,
-              end_time: '2017-02-03T08:00:00+0000',
-            },
-            {
-              value: 87175,
-              end_time: '2017-02-04T08:00:00+0000',
-            },
-          ],
-          title: 'Daily unique active threads count by thread fbid',
-          description:
-            'Daily: total unique active threads created between users and page.',
-          id:
-            '1234567/insights/?metric=page_messages_active_threads_unique/day',
-        },
-      ]);
+      expect(res).toEqual({
+        name: 'page_messages_active_threads_unique',
+        period: 'day',
+        values: [
+          {
+            value: 83111,
+            end_time: '2017-02-02T08:00:00+0000',
+          },
+          {
+            value: 85215,
+            end_time: '2017-02-03T08:00:00+0000',
+          },
+          {
+            value: 87175,
+            end_time: '2017-02-04T08:00:00+0000',
+          },
+        ],
+        title: 'Daily unique active threads count by thread fbid',
+        description:
+          'Daily: total unique active threads created between users and page.',
+        id: '1234567/insights/?metric=page_messages_active_threads_unique/day',
+      });
     });
   });
 
@@ -195,31 +192,29 @@ describe('Page Messaging Insights API', () => {
 
       const res = await client.getBlockedConversations();
 
-      expect(res).toEqual([
-        {
-          name: 'page_messages_blocked_conversations_unique',
-          period: 'day',
-          values: [
-            {
-              value: 83111,
-              end_time: '2017-02-02T08:00:00+0000',
-            },
-            {
-              value: 85215,
-              end_time: '2017-02-03T08:00:00+0000',
-            },
-            {
-              value: 87175,
-              end_time: '2017-02-04T08:00:00+0000',
-            },
-          ],
-          title: 'Daily unique blocked conversations count',
-          description:
-            'Daily: The number of conversations with the Page that have been blocked.',
-          id:
-            '1234567/insights/?metric=page_messages_blocked_conversations_unique/day',
-        },
-      ]);
+      expect(res).toEqual({
+        name: 'page_messages_blocked_conversations_unique',
+        period: 'day',
+        values: [
+          {
+            value: 83111,
+            end_time: '2017-02-02T08:00:00+0000',
+          },
+          {
+            value: 85215,
+            end_time: '2017-02-03T08:00:00+0000',
+          },
+          {
+            value: 87175,
+            end_time: '2017-02-04T08:00:00+0000',
+          },
+        ],
+        title: 'Daily unique blocked conversations count',
+        description:
+          'Daily: The number of conversations with the Page that have been blocked.',
+        id:
+          '1234567/insights/?metric=page_messages_blocked_conversations_unique/day',
+      });
     });
   });
 
@@ -263,31 +258,29 @@ describe('Page Messaging Insights API', () => {
 
       const res = await client.getReportedConversations();
 
-      expect(res).toEqual([
-        {
-          name: 'page_messages_reported_conversations_unique',
-          period: 'day',
-          values: [
-            {
-              value: 83111,
-              end_time: '2017-02-02T08:00:00+0000',
-            },
-            {
-              value: 85215,
-              end_time: '2017-02-03T08:00:00+0000',
-            },
-            {
-              value: 87175,
-              end_time: '2017-02-04T08:00:00+0000',
-            },
-          ],
-          title: 'Daily unique reported conversations count',
-          description:
-            'Daily: The number of conversations from your Page that have been reported by people for reasons such as spam, or containing inappropriate content.',
-          id:
-            '1234567/insights/?metric=page_messages_reported_conversations_unique/day',
-        },
-      ]);
+      expect(res).toEqual({
+        name: 'page_messages_reported_conversations_unique',
+        period: 'day',
+        values: [
+          {
+            value: 83111,
+            end_time: '2017-02-02T08:00:00+0000',
+          },
+          {
+            value: 85215,
+            end_time: '2017-02-03T08:00:00+0000',
+          },
+          {
+            value: 87175,
+            end_time: '2017-02-04T08:00:00+0000',
+          },
+        ],
+        title: 'Daily unique reported conversations count',
+        description:
+          'Daily: The number of conversations from your Page that have been reported by people for reasons such as spam, or containing inappropriate content.',
+        id:
+          '1234567/insights/?metric=page_messages_reported_conversations_unique/day',
+      });
     });
   });
 
@@ -336,36 +329,34 @@ describe('Page Messaging Insights API', () => {
 
       const res = await client.getReportedConversationsByReportType();
 
-      expect(res).toEqual([
-        {
-          name: 'page_messages_reported_conversations_by_report_type_unique',
-          period: 'day',
-          values: [
-            {
-              value: {
-                spam: 0,
-                inappropriate: 0,
-                other: 0,
-              },
-              end_time: '2018-03-11T08:00:00+0000',
+      expect(res).toEqual({
+        name: 'page_messages_reported_conversations_by_report_type_unique',
+        period: 'day',
+        values: [
+          {
+            value: {
+              spam: 0,
+              inappropriate: 0,
+              other: 0,
             },
-            {
-              value: {
-                spam: 0,
-                inappropriate: 0,
-                other: 0,
-              },
-              end_time: '2018-03-12T07:00:00+0000',
+            end_time: '2018-03-11T08:00:00+0000',
+          },
+          {
+            value: {
+              spam: 0,
+              inappropriate: 0,
+              other: 0,
             },
-          ],
-          title:
-            'Daily unique reported conversations count broken down by report type',
-          description:
-            'Daily: The number of conversations from your Page that have been reported by people for reasons such as spam, or containing inappropriate content broken down by report type.',
-          id:
-            '1234567/insights/?metric=page_messages_reported_conversations_by_report_type_unique/day',
-        },
-      ]);
+            end_time: '2018-03-12T07:00:00+0000',
+          },
+        ],
+        title:
+          'Daily unique reported conversations count broken down by report type',
+        description:
+          'Daily: The number of conversations from your Page that have been reported by people for reasons such as spam, or containing inappropriate content broken down by report type.',
+        id:
+          '1234567/insights/?metric=page_messages_reported_conversations_by_report_type_unique/day',
+      });
     });
   });
 
@@ -418,40 +409,37 @@ describe('Page Messaging Insights API', () => {
 
       const res = await client.getDailyUniqueConversationCounts();
 
-      expect(res).toEqual([
-        {
-          name: 'page_messages_feedback_by_action_unique',
-          period: 'day',
-          values: [
-            {
-              value: {
-                TURN_ON: 40,
-                TURN_OFF: 167,
-                DELETE: 720,
-                OTHER: 0,
-                REPORT_SPAM: 0,
-              },
-              end_time: '2017-02-02T08:00:00+0000',
+      expect(res).toEqual({
+        name: 'page_messages_feedback_by_action_unique',
+        period: 'day',
+        values: [
+          {
+            value: {
+              TURN_ON: 40,
+              TURN_OFF: 167,
+              DELETE: 720,
+              OTHER: 0,
+              REPORT_SPAM: 0,
             },
-            {
-              value: {
-                TURN_ON: 38,
-                DELETE: 654,
-                TURN_OFF: 155,
-                REPORT_SPAM: 1,
-                OTHER: 0,
-              },
-              end_time: '2017-02-03T08:00:00+0000',
+            end_time: '2017-02-02T08:00:00+0000',
+          },
+          {
+            value: {
+              TURN_ON: 38,
+              DELETE: 654,
+              TURN_OFF: 155,
+              REPORT_SPAM: 1,
+              OTHER: 0,
             },
-          ],
-          title:
-            'Daily unique conversation count broken down by user feedback actions',
-          description:
-            'Daily: total unique active threads created between users and page.',
-          id:
-            '1234567/insights/?metric=page_messages_active_threads_unique/day',
-        },
-      ]);
+            end_time: '2017-02-03T08:00:00+0000',
+          },
+        ],
+        title:
+          'Daily unique conversation count broken down by user feedback actions',
+        description:
+          'Daily: total unique active threads created between users and page.',
+        id: '1234567/insights/?metric=page_messages_active_threads_unique/day',
+      });
     });
   });
 });


### PR DESCRIPTION
Affected APIs:

- getDailyUniqueActiveThreadCounts (**will be renamed to getActiveThreads**) #296
- getBlockedConversations
- getReportedConversations
- getReportedConversationsByReportType
- getDailyUniqueConversationCounts (**deprecated**)

Before: 

```js
client.getBlockedConversations().then(counts => {
  console.log(counts);
  // [
  //   {
  //     "name": "page_messages_blocked_conversations_unique",
  //     "period": "day",
  //     "values": [
  //       {
  //         "value": "<VALUE>",
  //         "end_time": "<UTC_TIMESTAMP>"
  //       },
  //       {
  //         "value": "<VALUE>",
  //         "end_time": "<UTC_TIMESTAMP>"
  //       }
  //    ]
  //   }
  // ]
});
```

After: 

```js
client.getBlockedConversations().then(counts => {
  console.log(counts);
  //   {
  //     "name": "page_messages_blocked_conversations_unique",
  //     "period": "day",
  //     "values": [
  //       {
  //         "value": "<VALUE>",
  //         "end_time": "<UTC_TIMESTAMP>"
  //       },
  //       {
  //         "value": "<VALUE>",
  //         "end_time": "<UTC_TIMESTAMP>"
  //       }
  //    ]
  //   }
});
```