### PR TITLE
allow pass object as image, audio, video, sticker args

### DIFF
--- a/packages/messaging-api-line/src/Line.js
+++ b/packages/messaging-api-line/src/Line.js
@@ -9,38 +9,76 @@ import type {
   ImageCarouselColumnObject,
 } from './LineTypes';
 
-function createText(text: string) {
+function createText(text: string): Object {
   return {
     type: 'text',
     text,
   };
 }
 
-function createImage(contentUrl: string, previewUrl: ?string) {
+function createImage(
+  contentUrlOrImage: string | Object,
+  previewUrl: ?string
+): Object {
+  if (typeof contentUrlOrImage === 'object') {
+    const image = contentUrlOrImage;
+    return {
+      type: 'image',
+      originalContentUrl: image.originalContentUrl,
+      previewImageUrl: image.previewImageUrl || image.originalContentUrl,
+    };
+  }
   return {
     type: 'image',
-    originalContentUrl: contentUrl,
-    previewImageUrl: previewUrl || contentUrl,
+    originalContentUrl: contentUrlOrImage,
+    previewImageUrl: previewUrl || contentUrlOrImage,
   };
 }
 
-function createVideo(contentUrl: string, previewUrl: string) {
+function createVideo(
+  contentUrlOrVideo: string | Object,
+  previewUrl: ?string
+): Object {
+  if (typeof contentUrlOrVideo === 'object') {
+    const video = contentUrlOrVideo;
+    return {
+      type: 'video',
+      originalContentUrl: video.originalContentUrl,
+      previewImageUrl: video.previewImageUrl,
+    };
+  }
   return {
     type: 'video',
-    originalContentUrl: contentUrl,
+    originalContentUrl: contentUrlOrVideo,
     previewImageUrl: previewUrl,
   };
 }
 
-function createAudio(contentUrl: string, duration: number) {
+function createAudio(
+  contentUrlOrAudio: string | Object,
+  duration: ?number
+): Object {
+  if (typeof contentUrlOrAudio === 'object') {
+    const audio = contentUrlOrAudio;
+    return {
+      type: 'audio',
+      originalContentUrl: audio.originalContentUrl,
+      duration: audio.duration,
+    };
+  }
   return {
     type: 'audio',
-    originalContentUrl: contentUrl,
+    originalContentUrl: contentUrlOrAudio,
     duration,
   };
 }
 
-function createLocation({ title, address, latitude, longitude }: Location) {
+function createLocation({
+  title,
+  address,
+  latitude,
+  longitude,
+}: Location): Object {
   return {
     type: 'location',
     title,
@@ -50,10 +88,21 @@ function createLocation({ title, address, latitude, longitude }: Location) {
   };
 }
 
-function createSticker(packageId: string, stickerId: string) {
+function createSticker(
+  packageIdOrSticker: string | Object,
+  stickerId: ?string
+): Object {
+  if (typeof packageIdOrSticker === 'object') {
+    const sticker = packageIdOrSticker;
+    return {
+      type: 'sticker',
+      packageId: sticker.packageId,
+      stickerId: sticker.stickerId,
+    };
+  }
   return {
     type: 'sticker',
-    packageId,
+    packageId: packageIdOrSticker,
     stickerId,
   };
 }
@@ -76,7 +125,7 @@ function createImagemap(
     baseWidth: number,
     actions: Array<ImageMapAction>,
   }
-) {
+): Object {
   return {
     type: 'imagemap',
     baseUrl,
@@ -89,7 +138,7 @@ function createImagemap(
   };
 }
 
-function createTemplate(altText: string, template: Template) {
+function createTemplate(altText: string, template: Template): Object {
   return {
     type: 'template',
     altText,
@@ -116,7 +165,7 @@ function createButtonTemplate(
     text: string,
     actions: Array<TemplateAction>,
   }
-) {
+): Object {
   return createTemplate(altText, {
     type: 'buttons',
     thumbnailImageUrl,
@@ -138,7 +187,7 @@ function createConfirmTemplate(
     text: string,
     actions: Array<TemplateAction>,
   }
-) {
+): Object {
   return createTemplate(altText, {
     type: 'confirm',
     text,
@@ -155,8 +204,8 @@ function createCarouselTemplate(
   }: {
     imageAspectRatio?: 'rectangle' | 'square',
     imageSize?: 'cover' | 'contain',
-  }
-) {
+  } = {}
+): Object {
   return createTemplate(altText, {
     type: 'carousel',
     columns,
@@ -168,7 +217,7 @@ function createCarouselTemplate(
 function createImageCarouselTemplate(
   altText: string,
   columns: Array<ImageCarouselColumnObject>
-) {
+): Object {
   return createTemplate(altText, {
     type: 'image_carousel',
     columns,

--- a/packages/messaging-api-line/src/LineClient.js
+++ b/packages/messaging-api-line/src/LineClient.js
@@ -105,25 +105,26 @@ export default class LineClient {
   _sendImage = (
     type: SendType,
     target: SendTarget,
-    contentUrl: string,
+    contentUrlOrImage: string | Object,
     previewUrl: ?string
-  ) => this._send(type, target, [Line.createImage(contentUrl, previewUrl)]);
+  ) =>
+    this._send(type, target, [Line.createImage(contentUrlOrImage, previewUrl)]);
 
   _sendVideo = (
     type: SendType,
     target: SendTarget,
-    contentUrl: string,
+    contentUrlOrVideo: string | Object,
     previewUrl: string
   ): Promise<MutationSuccessResponse> =>
-    this._send(type, target, [Line.createVideo(contentUrl, previewUrl)]);
+    this._send(type, target, [Line.createVideo(contentUrlOrVideo, previewUrl)]);
 
   _sendAudio = (
     type: SendType,
     target: SendTarget,
-    contentUrl: string,
-    duration: number
+    contentUrlOrAudio: string | Object,
+    duration: ?number
   ): Promise<MutationSuccessResponse> =>
-    this._send(type, target, [Line.createAudio(contentUrl, duration)]);
+    this._send(type, target, [Line.createAudio(contentUrlOrAudio, duration)]);
 
   _sendLocation = (
     type: SendType,
@@ -142,10 +143,12 @@ export default class LineClient {
   _sendSticker = (
     type: SendType,
     target: SendTarget,
-    packageId: string,
-    stickerId: string
+    packageIdOrSticker: string | Object,
+    stickerId: ?string
   ): Promise<MutationSuccessResponse> =>
-    this._send(type, target, [Line.createSticker(packageId, stickerId)]);
+    this._send(type, target, [
+      Line.createSticker(packageIdOrSticker, stickerId),
+    ]);
 
   /**
    * Imagemap Message

--- a/packages/messaging-api-line/src/__tests__/Line.spec.js
+++ b/packages/messaging-api-line/src/__tests__/Line.spec.js
@@ -1,0 +1,610 @@
+import Line from '../Line';
+
+describe('#createText', () => {
+  it('should return text message object', () => {
+    expect(Line.createText('t')).toEqual({ type: 'text', text: 't' });
+  });
+});
+
+describe('#createImage', () => {
+  it('should return image message object', () => {
+    expect(
+      Line.createImage(
+        'http://example.com/img1.jpg',
+        'http://example.com/img2.jpg'
+      )
+    ).toEqual({
+      type: 'image',
+      originalContentUrl: 'http://example.com/img1.jpg',
+      previewImageUrl: 'http://example.com/img2.jpg',
+    });
+  });
+
+  it('should work with object', () => {
+    expect(
+      Line.createImage({
+        originalContentUrl: 'http://example.com/img1.jpg',
+        previewImageUrl: 'http://example.com/img2.jpg',
+      })
+    ).toEqual({
+      type: 'image',
+      originalContentUrl: 'http://example.com/img1.jpg',
+      previewImageUrl: 'http://example.com/img2.jpg',
+    });
+  });
+});
+
+describe('#createVideo', () => {
+  it('should return video message object', () => {
+    expect(
+      Line.createVideo(
+        'http://example.com/video.mp4',
+        'http://example.com/img.jpg'
+      )
+    ).toEqual({
+      type: 'video',
+      originalContentUrl: 'http://example.com/video.mp4',
+      previewImageUrl: 'http://example.com/img.jpg',
+    });
+  });
+
+  it('should work with object', () => {
+    expect(
+      Line.createVideo({
+        originalContentUrl: 'http://example.com/video.mp4',
+        previewImageUrl: 'http://example.com/img.jpg',
+      })
+    ).toEqual({
+      type: 'video',
+      originalContentUrl: 'http://example.com/video.mp4',
+      previewImageUrl: 'http://example.com/img.jpg',
+    });
+  });
+});
+
+describe('#createAudio', () => {
+  it('should return audio message object', () => {
+    expect(Line.createAudio('http://example.com/audio.mp3', 240000)).toEqual({
+      type: 'audio',
+      originalContentUrl: 'http://example.com/audio.mp3',
+      duration: 240000,
+    });
+  });
+
+  it('should work with object', () => {
+    expect(
+      Line.createAudio({
+        originalContentUrl: 'http://example.com/audio.mp3',
+        duration: 240000,
+      })
+    ).toEqual({
+      type: 'audio',
+      originalContentUrl: 'http://example.com/audio.mp3',
+      duration: 240000,
+    });
+  });
+});
+
+describe('#createLocation', () => {
+  it('should return location message object', () => {
+    expect(
+      Line.createLocation({
+        title: 'my location',
+        address: '〒150-0002 東京都渋谷区渋谷２丁目２１−１',
+        latitude: 35.65910807942215,
+        longitude: 139.70372892916203,
+      })
+    ).toEqual({
+      type: 'location',
+      title: 'my location',
+      address: '〒150-0002 東京都渋谷区渋谷２丁目２１−１',
+      latitude: 35.65910807942215,
+      longitude: 139.70372892916203,
+    });
+  });
+});
+
+describe('#createSticker', () => {
+  it('should return sticker message object', () => {
+    expect(Line.createSticker('1', '1')).toEqual({
+      type: 'sticker',
+      packageId: '1',
+      stickerId: '1',
+    });
+  });
+
+  it('should work with object', () => {
+    expect(
+      Line.createSticker({
+        packageId: '1',
+        stickerId: '1',
+      })
+    ).toEqual({
+      type: 'sticker',
+      packageId: '1',
+      stickerId: '1',
+    });
+  });
+});
+
+describe('#createImagemap', () => {
+  it('should return imagemap message object', () => {
+    expect(
+      Line.createImagemap('this is an imagemap', {
+        baseUrl: 'https://example.com/bot/images/rm001',
+        baseSize: {
+          width: 1040,
+          height: 1040,
+        },
+        actions: [
+          {
+            type: 'uri',
+            linkUri: 'https://example.com/',
+            area: {
+              x: 0,
+              y: 0,
+              width: 520,
+              height: 1040,
+            },
+          },
+          {
+            type: 'message',
+            text: 'hello',
+            area: {
+              x: 520,
+              y: 0,
+              width: 520,
+              height: 1040,
+            },
+          },
+        ],
+      })
+    ).toEqual({
+      type: 'imagemap',
+      altText: 'this is an imagemap',
+      baseUrl: 'https://example.com/bot/images/rm001',
+      baseSize: {
+        width: 1040,
+        height: 1040,
+      },
+      actions: [
+        {
+          type: 'uri',
+          linkUri: 'https://example.com/',
+          area: {
+            x: 0,
+            y: 0,
+            width: 520,
+            height: 1040,
+          },
+        },
+        {
+          type: 'message',
+          text: 'hello',
+          area: {
+            x: 520,
+            y: 0,
+            width: 520,
+            height: 1040,
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe('#createImagemap', () => {
+  it('should return imagemap message object', () => {
+    expect(
+      Line.createImagemap('this is an imagemap', {
+        baseUrl: 'https://example.com/bot/images/rm001',
+        baseSize: {
+          width: 1040,
+          height: 1040,
+        },
+        actions: [
+          {
+            type: 'uri',
+            linkUri: 'https://example.com/',
+            area: {
+              x: 0,
+              y: 0,
+              width: 520,
+              height: 1040,
+            },
+          },
+          {
+            type: 'message',
+            text: 'hello',
+            area: {
+              x: 520,
+              y: 0,
+              width: 520,
+              height: 1040,
+            },
+          },
+        ],
+      })
+    ).toEqual({
+      type: 'imagemap',
+      altText: 'this is an imagemap',
+      baseUrl: 'https://example.com/bot/images/rm001',
+      baseSize: {
+        width: 1040,
+        height: 1040,
+      },
+      actions: [
+        {
+          type: 'uri',
+          linkUri: 'https://example.com/',
+          area: {
+            x: 0,
+            y: 0,
+            width: 520,
+            height: 1040,
+          },
+        },
+        {
+          type: 'message',
+          text: 'hello',
+          area: {
+            x: 520,
+            y: 0,
+            width: 520,
+            height: 1040,
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe('#createTemplate', () => {
+  it('should return template message object', () => {
+    expect(
+      Line.createTemplate('this is a buttons template', {
+        type: 'buttons',
+        text: 'Are you sure?',
+        actions: [
+          {
+            type: 'message',
+            label: 'Yes',
+            text: 'yes',
+          },
+          {
+            type: 'message',
+            label: 'No',
+            text: 'no',
+          },
+        ],
+      })
+    ).toEqual({
+      type: 'template',
+      altText: 'this is a buttons template',
+      template: {
+        type: 'buttons',
+        text: 'Are you sure?',
+        actions: [
+          {
+            type: 'message',
+            label: 'Yes',
+            text: 'yes',
+          },
+          {
+            type: 'message',
+            label: 'No',
+            text: 'no',
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe('#createTemplate', () => {
+  it('should return template message object', () => {
+    expect(
+      Line.createTemplate('this is a confirm template', {
+        type: 'confirm',
+        text: 'Are you sure?',
+        actions: [
+          {
+            type: 'message',
+            label: 'Yes',
+            text: 'yes',
+          },
+          {
+            type: 'message',
+            label: 'No',
+            text: 'no',
+          },
+        ],
+      })
+    ).toEqual({
+      type: 'template',
+      altText: 'this is a confirm template',
+      template: {
+        type: 'confirm',
+        text: 'Are you sure?',
+        actions: [
+          {
+            type: 'message',
+            label: 'Yes',
+            text: 'yes',
+          },
+          {
+            type: 'message',
+            label: 'No',
+            text: 'no',
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe('#createButtonTemplate', () => {
+  it('should return buttons template message object', () => {
+    expect(
+      Line.createButtonTemplate('this is a buttons template', {
+        thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+        title: 'Menu',
+        text: 'Please select',
+        actions: [
+          {
+            type: 'postback',
+            label: 'Buy',
+            data: 'action=buy&itemid=123',
+          },
+          {
+            type: 'postback',
+            label: 'Add to cart',
+            data: 'action=add&itemid=123',
+          },
+          {
+            type: 'uri',
+            label: 'View detail',
+            uri: 'http://example.com/page/123',
+          },
+        ],
+      })
+    ).toEqual({
+      type: 'template',
+      altText: 'this is a buttons template',
+      template: {
+        type: 'buttons',
+        thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+        title: 'Menu',
+        text: 'Please select',
+        actions: [
+          {
+            type: 'postback',
+            label: 'Buy',
+            data: 'action=buy&itemid=123',
+          },
+          {
+            type: 'postback',
+            label: 'Add to cart',
+            data: 'action=add&itemid=123',
+          },
+          {
+            type: 'uri',
+            label: 'View detail',
+            uri: 'http://example.com/page/123',
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe('#createConfirmTemplate', () => {
+  it('should return confirm template message object', () => {
+    expect(
+      Line.createConfirmTemplate('this is a confirm template', {
+        text: 'Are you sure?',
+        actions: [
+          {
+            type: 'message',
+            label: 'Yes',
+            text: 'yes',
+          },
+          {
+            type: 'message',
+            label: 'No',
+            text: 'no',
+          },
+        ],
+      })
+    ).toEqual({
+      type: 'template',
+      altText: 'this is a confirm template',
+      template: {
+        type: 'confirm',
+        text: 'Are you sure?',
+        actions: [
+          {
+            type: 'message',
+            label: 'Yes',
+            text: 'yes',
+          },
+          {
+            type: 'message',
+            label: 'No',
+            text: 'no',
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe('#createCarouselTemplate', () => {
+  it('should return carousel template message object', () => {
+    expect(
+      Line.createCarouselTemplate('this is a carousel template', [
+        {
+          thumbnailImageUrl: 'https://example.com/bot/images/item1.jpg',
+          title: 'this is menu',
+          text: 'description',
+          actions: [
+            {
+              type: 'postback',
+              label: 'Buy',
+              data: 'action=buy&itemid=111',
+            },
+            {
+              type: 'postback',
+              label: 'Add to cart',
+              data: 'action=add&itemid=111',
+            },
+            {
+              type: 'uri',
+              label: 'View detail',
+              uri: 'http://example.com/page/111',
+            },
+          ],
+        },
+        {
+          thumbnailImageUrl: 'https://example.com/bot/images/item2.jpg',
+          title: 'this is menu',
+          text: 'description',
+          actions: [
+            {
+              type: 'postback',
+              label: 'Buy',
+              data: 'action=buy&itemid=222',
+            },
+            {
+              type: 'postback',
+              label: 'Add to cart',
+              data: 'action=add&itemid=222',
+            },
+            {
+              type: 'uri',
+              label: 'View detail',
+              uri: 'http://example.com/page/222',
+            },
+          ],
+        },
+      ])
+    ).toEqual({
+      type: 'template',
+      altText: 'this is a carousel template',
+      template: {
+        type: 'carousel',
+        columns: [
+          {
+            thumbnailImageUrl: 'https://example.com/bot/images/item1.jpg',
+            title: 'this is menu',
+            text: 'description',
+            actions: [
+              {
+                type: 'postback',
+                label: 'Buy',
+                data: 'action=buy&itemid=111',
+              },
+              {
+                type: 'postback',
+                label: 'Add to cart',
+                data: 'action=add&itemid=111',
+              },
+              {
+                type: 'uri',
+                label: 'View detail',
+                uri: 'http://example.com/page/111',
+              },
+            ],
+          },
+          {
+            thumbnailImageUrl: 'https://example.com/bot/images/item2.jpg',
+            title: 'this is menu',
+            text: 'description',
+            actions: [
+              {
+                type: 'postback',
+                label: 'Buy',
+                data: 'action=buy&itemid=222',
+              },
+              {
+                type: 'postback',
+                label: 'Add to cart',
+                data: 'action=add&itemid=222',
+              },
+              {
+                type: 'uri',
+                label: 'View detail',
+                uri: 'http://example.com/page/222',
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe('#createImageCarouselTemplate', () => {
+  it('should return image carousel template message object', () => {
+    expect(
+      Line.createImageCarouselTemplate('this is a image carousel template', [
+        {
+          imageUrl: 'https://example.com/bot/images/item1.jpg',
+          action: {
+            type: 'postback',
+            label: 'Buy',
+            data: 'action=buy&itemid=111',
+          },
+        },
+        {
+          imageUrl: 'https://example.com/bot/images/item2.jpg',
+          action: {
+            type: 'message',
+            label: 'Yes',
+            text: 'yes',
+          },
+        },
+        {
+          imageUrl: 'https://example.com/bot/images/item3.jpg',
+          action: {
+            type: 'uri',
+            label: 'View detail',
+            uri: 'http://example.com/page/222',
+          },
+        },
+      ])
+    ).toEqual({
+      type: 'template',
+      altText: 'this is a image carousel template',
+      template: {
+        type: 'image_carousel',
+        columns: [
+          {
+            imageUrl: 'https://example.com/bot/images/item1.jpg',
+            action: {
+              type: 'postback',
+              label: 'Buy',
+              data: 'action=buy&itemid=111',
+            },
+          },
+          {
+            imageUrl: 'https://example.com/bot/images/item2.jpg',
+            action: {
+              type: 'message',
+              label: 'Yes',
+              text: 'yes',
+            },
+          },
+          {
+            imageUrl: 'https://example.com/bot/images/item3.jpg',
+            action: {
+              type: 'uri',
+              label: 'View detail',
+              uri: 'http://example.com/page/222',
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/messaging-api-line/src/__tests__/LineClient-multicast.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-multicast.spec.js
@@ -143,6 +143,32 @@ describe('Multicast', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('should call multicast api with object image arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/multicast', {
+          to: [RECIPIENT_ID],
+          messages: [
+            {
+              type: 'image',
+              originalContentUrl: 'https://example.com/original.jpg',
+              previewImageUrl: 'https://example.com/preview.jpg',
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.multicastImage([RECIPIENT_ID], {
+        originalContentUrl: 'https://example.com/original.jpg',
+        previewImageUrl: 'https://example.com/preview.jpg',
+      });
+
+      expect(res).toEqual(reply);
+    });
   });
 
   describe('#multicastVideo', () => {
@@ -172,6 +198,32 @@ describe('Multicast', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('should call multicast api with object video arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/multicast', {
+          to: [RECIPIENT_ID],
+          messages: [
+            {
+              type: 'video',
+              originalContentUrl: 'https://example.com/original.mp4',
+              previewImageUrl: 'https://example.com/preview.jpg',
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.multicastVideo([RECIPIENT_ID], {
+        originalContentUrl: 'https://example.com/original.mp4',
+        previewImageUrl: 'https://example.com/preview.jpg',
+      });
+
+      expect(res).toEqual(reply);
+    });
   });
 
   describe('#multicastAudio', () => {
@@ -198,6 +250,32 @@ describe('Multicast', () => {
         'https://example.com/original.m4a',
         240000
       );
+
+      expect(res).toEqual(reply);
+    });
+
+    it('should call multicast api with object audio arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/multicast', {
+          to: [RECIPIENT_ID],
+          messages: [
+            {
+              type: 'audio',
+              originalContentUrl: 'https://example.com/original.m4a',
+              duration: 240000,
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.multicastAudio([RECIPIENT_ID], {
+        originalContentUrl: 'https://example.com/original.m4a',
+        duration: 240000,
+      });
 
       expect(res).toEqual(reply);
     });
@@ -255,6 +333,32 @@ describe('Multicast', () => {
         .reply(200, reply, headers);
 
       const res = await client.multicastSticker([RECIPIENT_ID], '1', '1');
+
+      expect(res).toEqual(reply);
+    });
+
+    it('should call multicast api with object sticker arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/multicast', {
+          to: [RECIPIENT_ID],
+          messages: [
+            {
+              type: 'sticker',
+              packageId: '1',
+              stickerId: '1',
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.multicastSticker([RECIPIENT_ID], {
+        packageId: '1',
+        stickerId: '1',
+      });
 
       expect(res).toEqual(reply);
     });

--- a/packages/messaging-api-line/src/__tests__/LineClient-push.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-push.spec.js
@@ -140,6 +140,32 @@ describe('Push Message', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('should call push api with object image arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/push', {
+          to: RECIPIENT_ID,
+          messages: [
+            {
+              type: 'image',
+              originalContentUrl: 'https://example.com/original.jpg',
+              previewImageUrl: 'https://example.com/preview.jpg',
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.pushImage(RECIPIENT_ID, {
+        originalContentUrl: 'https://example.com/original.jpg',
+        previewImageUrl: 'https://example.com/preview.jpg',
+      });
+
+      expect(res).toEqual(reply);
+    });
   });
 
   describe('#pushVideo', () => {
@@ -169,6 +195,32 @@ describe('Push Message', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('should call push api with object video arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/push', {
+          to: RECIPIENT_ID,
+          messages: [
+            {
+              type: 'video',
+              originalContentUrl: 'https://example.com/original.mp4',
+              previewImageUrl: 'https://example.com/preview.jpg',
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.pushVideo(RECIPIENT_ID, {
+        originalContentUrl: 'https://example.com/original.mp4',
+        previewImageUrl: 'https://example.com/preview.jpg',
+      });
+
+      expect(res).toEqual(reply);
+    });
   });
 
   describe('#pushAudio', () => {
@@ -195,6 +247,32 @@ describe('Push Message', () => {
         'https://example.com/original.m4a',
         240000
       );
+
+      expect(res).toEqual(reply);
+    });
+
+    it('should call push api with object audio arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/push', {
+          to: RECIPIENT_ID,
+          messages: [
+            {
+              type: 'audio',
+              originalContentUrl: 'https://example.com/original.m4a',
+              duration: 240000,
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.pushAudio(RECIPIENT_ID, {
+        originalContentUrl: 'https://example.com/original.m4a',
+        duration: 240000,
+      });
 
       expect(res).toEqual(reply);
     });
@@ -252,6 +330,32 @@ describe('Push Message', () => {
         .reply(200, reply, headers);
 
       const res = await client.pushSticker(RECIPIENT_ID, '1', '1');
+
+      expect(res).toEqual(reply);
+    });
+
+    it('should call push api with object sticker arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/push', {
+          to: RECIPIENT_ID,
+          messages: [
+            {
+              type: 'sticker',
+              packageId: '1',
+              stickerId: '1',
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.pushSticker(RECIPIENT_ID, {
+        packageId: '1',
+        stickerId: '1',
+      });
 
       expect(res).toEqual(reply);
     });

--- a/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.js
@@ -140,6 +140,32 @@ describe('Reply Message', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('should call reply api with object image arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/reply', {
+          replyToken: REPLY_TOKEN,
+          messages: [
+            {
+              type: 'image',
+              originalContentUrl: 'https://example.com/original.jpg',
+              previewImageUrl: 'https://example.com/preview.jpg',
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.replyImage(REPLY_TOKEN, {
+        originalContentUrl: 'https://example.com/original.jpg',
+        previewImageUrl: 'https://example.com/preview.jpg',
+      });
+
+      expect(res).toEqual(reply);
+    });
   });
 
   describe('#replyVideo', () => {
@@ -169,6 +195,32 @@ describe('Reply Message', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('should call reply api with object video arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/reply', {
+          replyToken: REPLY_TOKEN,
+          messages: [
+            {
+              type: 'video',
+              originalContentUrl: 'https://example.com/original.mp4',
+              previewImageUrl: 'https://example.com/preview.jpg',
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.replyVideo(REPLY_TOKEN, {
+        originalContentUrl: 'https://example.com/original.mp4',
+        previewImageUrl: 'https://example.com/preview.jpg',
+      });
+
+      expect(res).toEqual(reply);
+    });
   });
 
   describe('#replyAudio', () => {
@@ -195,6 +247,32 @@ describe('Reply Message', () => {
         'https://example.com/original.m4a',
         240000
       );
+
+      expect(res).toEqual(reply);
+    });
+
+    it('should call reply api with object audio arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/reply', {
+          replyToken: REPLY_TOKEN,
+          messages: [
+            {
+              type: 'audio',
+              originalContentUrl: 'https://example.com/original.m4a',
+              duration: 240000,
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.replyAudio(REPLY_TOKEN, {
+        originalContentUrl: 'https://example.com/original.m4a',
+        duration: 240000,
+      });
 
       expect(res).toEqual(reply);
     });
@@ -252,6 +330,32 @@ describe('Reply Message', () => {
         .reply(200, reply, headers);
 
       const res = await client.replySticker(REPLY_TOKEN, '1', '1');
+
+      expect(res).toEqual(reply);
+    });
+
+    it('should call reply api with object sticker arg', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost('/message/reply', {
+          replyToken: REPLY_TOKEN,
+          messages: [
+            {
+              type: 'sticker',
+              packageId: '1',
+              stickerId: '1',
+            },
+          ],
+        })
+        .reply(200, reply, headers);
+
+      const res = await client.replySticker(REPLY_TOKEN, {
+        packageId: '1',
+        stickerId: '1',
+      });
 
       expect(res).toEqual(reply);
     });


### PR DESCRIPTION
Before:

```js
client.pushImage(RECIPIENT_ID,'https://example.com/original.jpg');
client.pushVideo(
  RECIPIENT_ID,
  'https://example.com/original.mp4',
  'https://example.com/preview.jpg'
)
client.pushAudio(
  RECIPIENT_ID,
  'https://example.com/original.m4a',
  240000
);
client.pushSticker(RECIPIENT_ID, '1', '1');
```

After this, it can accept object too:

```js
client.pushImage(RECIPIENT_ID, {
  originalContentUrl: 'https://example.com/original.jpg',
  previewImageUrl: 'https://example.com/preview.jpg',
});
client.pushVideo(RECIPIENT_ID, {
  originalContentUrl: 'https://example.com/original.mp4',
  previewImageUrl: 'https://example.com/preview.jpg',
});
client.pushAudio(RECIPIENT_ID, {
  originalContentUrl: 'https://example.com/original.m4a',
  duration: 240000,
});
client.pushSticker(RECIPIENT_ID, {
  packageId: '1',
  stickerId: '1',
});
```

Improve readability a lot.