### PR TITLE
handle network error better by fallback to original message

### DIFF
--- a/packages/axios-error/src/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/axios-error/src/__tests__/__snapshots__/index.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should support error without axios data 1`] = `
+"
+Error: boom....
+  at Object.<anonymous> (/Users/xxx/messaging-apis/packages/axios-error/src/__tests__/index.spec.js:16:19)
+  at Generator.throw (<anonymous>)
+  at step (/Users/xxx/messaging-apis/packages/axios-error/src/__tests__/index.spec.js:4:336)
+  at /Users/xxx/messaging-apis/packages/axios-error/src/__tests__/index.spec.js:4:535
+  at <anonymous>
+
+
+Error Message -
+  custom error
+
+
+"
+`;
+
 exports[`should work 1`] = `
 "
 Error: boom....
@@ -28,5 +45,29 @@ Response Data -
   {
     \\"error_status\\": \\"boom....\\"
   }
+"
+`;
+
+exports[`should work with undefined response 1`] = `
+"
+Error: boom....
+  at Object.<anonymous> (/Users/xxx/messaging-apis/packages/axios-error/src/__tests__/index.spec.js:16:19)
+  at Generator.throw (<anonymous>)
+  at step (/Users/xxx/messaging-apis/packages/axios-error/src/__tests__/index.spec.js:4:336)
+  at /Users/xxx/messaging-apis/packages/axios-error/src/__tests__/index.spec.js:4:535
+  at <anonymous>
+
+
+Error Message -
+  read ECONNRESET
+
+Request -
+  POST /
+
+Request Data -
+  {
+    \\"x\\": 1
+  }
+
 "
 `;

--- a/packages/axios-error/src/__tests__/index.spec.js
+++ b/packages/axios-error/src/__tests__/index.spec.js
@@ -32,3 +32,27 @@ it('should work', async () => {
     expect(error.inspect()).toMatchSnapshot();
   }
 });
+
+it('should work with undefined response', async () => {
+  try {
+    await axios.post('/', { x: 1 });
+  } catch (err) {
+    // overwrite to undefined
+    // https://github.com/Yoctol/bottender/issues/246
+    err.response = undefined;
+
+    const error = new AxiosError('read ECONNRESET', err);
+
+    // overwrite stack to test it
+    error.stack = stack;
+
+    expect(error.inspect()).toMatchSnapshot();
+  }
+});
+
+it('should support error without axios data', () => {
+  const error = new AxiosError('custom error');
+  error.stack = stack;
+
+  expect(error.inspect()).toMatchSnapshot();
+});

--- a/packages/axios-error/src/index.js
+++ b/packages/axios-error/src/index.js
@@ -10,43 +10,63 @@ function json(data) {
 }
 
 module.exports = class AxiosError extends Error {
-  constructor(message, { config, request, response }) {
+  constructor(message, err = {}) {
     super(message);
+    const { config, request, response } = err;
+
     this.config = config;
     this.request = request;
     this.response = response;
   }
 
   inspect() {
-    let requestData = '';
-    if (this.config.data) {
+    let requestMessage = '';
+
+    if (this.config) {
       let { data } = this.config;
+
       try {
         data = JSON.parse(data);
       } catch (_) {} // eslint-disable-line
-      requestData = `
+
+      let requestData = '';
+
+      if (this.config.data) {
+        requestData = `
 Request Data -
-${indent(json(data))}
-`;
+${indent(json(data))}`;
+      }
+
+      requestMessage = `
+Request -
+  ${this.config.method.toUpperCase()} ${this.config.url}
+${requestData}`;
     }
-    let responseData = '';
-    if (this.response.data) {
-      responseData = `
+
+    let responseMessage = '';
+
+    if (this.response) {
+      let responseData;
+
+      if (this.response.data) {
+        responseData = `
 Response Data -
 ${indent(json(this.response.data))}`;
+      }
+
+      responseMessage = `
+Response -
+  ${this.response.status} ${this.response.statusText}
+${responseData}`;
     }
+
     return `
 ${this.stack}
 
 Error Message -
   ${this.message}
-
-Request -
-  ${this.config.method.toUpperCase()} ${this.config.url}
-${requestData}
-Response -
-  ${this.response.status} ${this.response.statusText}
-${responseData}
+${requestMessage}
+${responseMessage}
 `;
   }
 };

--- a/packages/messaging-api-line/src/LineClient.js
+++ b/packages/messaging-api-line/src/LineClient.js
@@ -31,14 +31,17 @@ type Axios = {
 };
 
 function handleError(err) {
-  const { message, details } = err.response.data;
-  let msg = `LINE API - ${message}`;
-  if (details && details.length > 0) {
-    details.forEach(detail => {
-      msg += `\n- ${detail.property}: ${detail.message}`;
-    });
+  if (err.response && err.response.data) {
+    const { message, details } = err.response.data;
+    let msg = `LINE API - ${message}`;
+    if (details && details.length > 0) {
+      details.forEach(detail => {
+        msg += `\n- ${detail.property}: ${detail.message}`;
+      });
+    }
+    throw new AxiosError(msg, err);
   }
-  throw new AxiosError(msg, err);
+  throw new AxiosError(err.message, err);
 }
 
 type ClientConfig = {

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -66,9 +66,12 @@ function extractVersion(version) {
 }
 
 function handleError(err) {
-  const { error } = err.response.data;
-  const msg = `Messenger API - ${error.code} ${error.type} ${error.message}`;
-  throw new AxiosError(msg, err);
+  if (err.response && err.response.data) {
+    const { error } = err.response.data;
+    const msg = `Messenger API - ${error.code} ${error.type} ${error.message}`;
+    throw new AxiosError(msg, err);
+  }
+  throw new AxiosError(err.message, err);
 }
 
 type ClientConfig = {

--- a/packages/messaging-api-slack/src/SlackOAuthClient.js
+++ b/packages/messaging-api-slack/src/SlackOAuthClient.js
@@ -105,23 +105,27 @@ export default class SlackOAuthClient {
     method: SlackAvailableMethod,
     body: Object = {}
   ): Promise<SlackOAuthAPIResponse> {
-    body.token = body.token || this._token; // eslint-disable-line no-param-reassign
-    const response = await this._axios.post(
-      method,
-      querystring.stringify(body)
-    );
+    try {
+      body.token = body.token || this._token; // eslint-disable-line no-param-reassign
+      const response = await this._axios.post(
+        method,
+        querystring.stringify(body)
+      );
 
-    const { data, config, request } = response;
+      const { data, config, request } = response;
 
-    if (!data.ok) {
-      throw new AxiosError(`Slack API - ${data.error}`, {
-        config,
-        request,
-        response,
-      });
+      if (!data.ok) {
+        throw new AxiosError(`Slack API - ${data.error}`, {
+          config,
+          request,
+          response,
+        });
+      }
+
+      return data;
+    } catch (err) {
+      throw new AxiosError(err.message, err);
     }
-
-    return data;
   }
 
   /**

--- a/packages/messaging-api-telegram/src/TelegramClient.js
+++ b/packages/messaging-api-telegram/src/TelegramClient.js
@@ -70,10 +70,13 @@ export default class TelegramClient {
 
       return data.result;
     } catch (err) {
-      const { error_code, description } = err.response.data;
-      const msg = `Telegram API - ${error_code} ${description || ''}`; // eslint-disable-line camelcase
+      if (err.response && err.response.data) {
+        const { error_code, description } = err.response.data;
+        const msg = `Telegram API - ${error_code} ${description || ''}`; // eslint-disable-line camelcase
 
-      throw new AxiosError(msg, err);
+        throw new AxiosError(msg, err);
+      }
+      throw new AxiosError(err.message, err);
     }
   }
 

--- a/packages/messaging-api-viber/src/ViberClient.js
+++ b/packages/messaging-api-viber/src/ViberClient.js
@@ -75,19 +75,23 @@ export default class ViberClient {
   }
 
   async _callAPI(...args: Array<any>) {
-    const response = await this._axios.post(...args);
+    try {
+      const response = await this._axios.post(...args);
 
-    const { data, config, request } = response;
+      const { data, config, request } = response;
 
-    if (data.status !== 0) {
-      throw new AxiosError(`Viber API - ${data.status_message}`, {
-        config,
-        request,
-        response,
-      });
+      if (data.status !== 0) {
+        throw new AxiosError(`Viber API - ${data.status_message}`, {
+          config,
+          request,
+          response,
+        });
+      }
+
+      return data;
+    } catch (err) {
+      throw new AxiosError(err.message, err);
     }
-
-    return data;
   }
 
   /**


### PR DESCRIPTION
#336 

Didn't change wechat part as it's slightly different from others.

will show something like
```
$ node demo.js

Error: getaddrinfo ENOTFOUND slack.com slack.com:443
    at D:\Yoctol\messaging-apis\packages\messaging-api-slack\lib\SlackOAuthClient.js:127:15
    at Generator.throw (<anonymous>)
    at step (D:\Yoctol\messaging-apis\packages\messaging-api-slack\lib\SlackOAuthClient.js:6:374)
    at D:\Yoctol\messaging-apis\packages\messaging-api-slack\lib\SlackOAuthClient.js:6:573
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)

Error Message -
  getaddrinfo ENOTFOUND slack.com slack.com:443

Request -
  POST https://slack.com/api/users.list

Request Data -
  "cursor=&token=my-token"
```
```
$ node demo.js

Error: getaddrinfo ENOTFOUND api.line.me api.line.me:443
    at handleError (D:\Yoctol\messaging-apis\packages\messaging-api-line\lib\LineClient.js:44:9)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)

Error Message -
  getaddrinfo ENOTFOUND api.line.me api.line.me:443

Request -
  POST https://api.line.me/v2/bot/user/U<my-user-id>/linkToken

```