### PR TITLE
support broadcast label predicates

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -1507,6 +1507,7 @@ The following message templates are not supported:
 | messageCreativeId       | `Number` | The `message_creative_id` of the message creative to send in the broadcast. |
 | options                 | `Object` | Other optional parameters.                                                  |
 | options.custom_label_id | `Number` | The id of custom label.                                                     |
+| options.targeting       | `Object` | The targeting config.                                                       |
 
 Example
 
@@ -1523,6 +1524,26 @@ To send a broadcast message to the set of PSIDs associated with a label, pass la
 
 ```js
 client.sendBroadcastMessage(938461089, { custom_label_id: LABEL_ID });
+```
+
+Or you can send broadcast messages with label predicates (`and`, `or`, `not`):
+
+```js
+import { MessengerBroadcast } from 'messaging-api-messenger';
+
+const { add, or, not } = MessengerBroadcast;
+
+client.sendBroadcastMessage(938461089, {
+  targeting: {
+    labels: and(
+      '<CUSTOM_LABEL_ID_1>'
+      or(
+        '<UNDER_25_CUSTOMERS_LABEL_ID>',
+        '<OVER_50_CUSTOMERS_LABEL_ID>'
+      )
+    ),
+  },
+});
 ```
 
 <br />

--- a/packages/messaging-api-messenger/src/MessengerBroadcast.js
+++ b/packages/messaging-api-messenger/src/MessengerBroadcast.js
@@ -1,0 +1,26 @@
+function and(...labels) {
+  return {
+    operator: 'AND',
+    values: labels,
+  };
+}
+
+function or(...labels) {
+  return {
+    operator: 'OR',
+    values: labels,
+  };
+}
+
+function not(...labels) {
+  return {
+    operator: 'NOT',
+    values: labels,
+  };
+}
+
+export default {
+  and,
+  or,
+  not,
+};

--- a/packages/messaging-api-messenger/src/__tests__/MessengerBroadcast.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerBroadcast.spec.js
@@ -22,3 +22,27 @@ it('#not', () => {
     values: ['<CUSTOM_LABEL_ID_1>', '<CUSTOM_LABEL_ID_2>'],
   });
 });
+
+it('nested predicate', () => {
+  expect(
+    and(
+      '<CUSTOM_LABEL_ID_1>',
+      or('<CUSTOM_LABEL_ID_2>', not('<CUSTOM_LABEL_ID_3>'))
+    )
+  ).toEqual({
+    operator: 'AND',
+    values: [
+      '<CUSTOM_LABEL_ID_1>',
+      {
+        operator: 'OR',
+        values: [
+          '<CUSTOM_LABEL_ID_2>',
+          {
+            operator: 'NOT',
+            values: ['<CUSTOM_LABEL_ID_3>'],
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/packages/messaging-api-messenger/src/__tests__/MessengerBroadcast.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerBroadcast.spec.js
@@ -1,0 +1,24 @@
+import MessengerBroadcast from '../MessengerBroadcast';
+
+const { and, or, not } = MessengerBroadcast;
+
+it('#and', () => {
+  expect(and('<CUSTOM_LABEL_ID_1>', '<CUSTOM_LABEL_ID_2>')).toEqual({
+    operator: 'AND',
+    values: ['<CUSTOM_LABEL_ID_1>', '<CUSTOM_LABEL_ID_2>'],
+  });
+});
+
+it('#or', () => {
+  expect(or('<CUSTOM_LABEL_ID_1>', '<CUSTOM_LABEL_ID_2>')).toEqual({
+    operator: 'OR',
+    values: ['<CUSTOM_LABEL_ID_1>', '<CUSTOM_LABEL_ID_2>'],
+  });
+});
+
+it('#not', () => {
+  expect(not('<CUSTOM_LABEL_ID_1>', '<CUSTOM_LABEL_ID_2>')).toEqual({
+    operator: 'NOT',
+    values: ['<CUSTOM_LABEL_ID_1>', '<CUSTOM_LABEL_ID_2>'],
+  });
+});

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-broadcast.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-broadcast.spec.js
@@ -1,6 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
 
 import MessengerClient from '../MessengerClient';
+import MessengerBroadcast from '../MessengerBroadcast';
 
 const USER_ID = '1QAZ2WSX';
 const ACCESS_TOKEN = '1234567890';
@@ -136,6 +137,40 @@ describe('broadcast api', () => {
 
       const res = await client.sendBroadcastMessage(938461089, {
         custom_label_id: 5678,
+      });
+
+      expect(res).toEqual(reply);
+    });
+
+    it('can send with label Predicates', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {
+        broadcast_id: 837,
+      };
+
+      mock
+        .onPost(`/me/broadcast_messages?access_token=${ACCESS_TOKEN}`, {
+          message_creative_id: 938461089,
+          targeting: {
+            labels: {
+              operator: 'OR',
+              values: [
+                '<UNDER_25_CUSTOMERS_LABEL_ID>',
+                '<OVER_50_CUSTOMERS_LABEL_ID>',
+              ],
+            },
+          },
+        })
+        .reply(200, reply);
+
+      const res = await client.sendBroadcastMessage(938461089, {
+        targeting: {
+          labels: MessengerBroadcast.or(
+            '<UNDER_25_CUSTOMERS_LABEL_ID>',
+            '<OVER_50_CUSTOMERS_LABEL_ID>'
+          ),
+        },
       });
 
       expect(res).toEqual(reply);

--- a/packages/messaging-api-messenger/src/__tests__/index.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/index.spec.js
@@ -1,7 +1,13 @@
-import { Messenger, MessengerBatch, MessengerClient } from '../';
+import {
+  Messenger,
+  MessengerBatch,
+  MessengerClient,
+  MessengerBroadcast,
+} from '../';
 
 it('should export api correctly', () => {
   expect(Messenger).toBeDefined();
   expect(MessengerBatch).toBeDefined();
   expect(MessengerClient).toBeDefined();
+  expect(MessengerBroadcast).toBeDefined();
 });

--- a/packages/messaging-api-messenger/src/index.js
+++ b/packages/messaging-api-messenger/src/index.js
@@ -3,9 +3,11 @@
 import Messenger from './Messenger';
 import MessengerBatch from './MessengerBatch';
 import MessengerClient from './MessengerClient';
+import MessengerBroadcast from './MessengerBroadcast';
 
 module.exports = {
   Messenger,
   MessengerBatch,
   MessengerClient,
+  MessengerBroadcast,
 };


### PR DESCRIPTION
Close #345

you can send broadcast messages with label predicates (`and`, `or`, `not`):

```js
import { MessengerBroadcast } from 'messaging-api-messenger';

const { add, or, not } = MessengerBroadcast;

client.sendBroadcastMessage(938461089, {
  targeting: {
    labels: and(
      '<CUSTOM_LABEL_ID_1>'
      or(
        '<UNDER_25_CUSTOMERS_LABEL_ID>',
        '<OVER_50_CUSTOMERS_LABEL_ID>'
      )
    ),
  },
});
```