### PR TITLE
upgrade to Graph API v3.0 by default

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -68,10 +68,10 @@ const client = MessengerClient.connect(accessToken);
 You can specify version of Facebook Graph API using second argument:
 
 ```js
-const client = MessengerClient.connect(accessToken, '2.9');
+const client = MessengerClient.connect(accessToken, '2.12');
 ```
 
-If it is not specified, version `2.11` will be used as default.
+If it is not specified, version `3.0` will be used as default.
 
 <br />
 

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -83,7 +83,7 @@ type ClientConfig = {
 export default class MessengerClient {
   static connect(
     accessTokenOrConfig: string | ClientConfig,
-    version?: string = '2.11'
+    version?: string = '3.0'
   ): MessengerClient {
     return new MessengerClient(accessTokenOrConfig, version);
   }
@@ -94,7 +94,7 @@ export default class MessengerClient {
 
   constructor(
     accessTokenOrConfig: string | ClientConfig,
-    version?: string = '2.11'
+    version?: string = '3.0'
   ) {
     let origin;
     if (accessTokenOrConfig && typeof accessTokenOrConfig === 'object') {
@@ -105,7 +105,7 @@ export default class MessengerClient {
         !config.version || typeof config.version === 'string',
         'Type of `version` must be string.'
       );
-      this._version = extractVersion(config.version || '2.11');
+      this._version = extractVersion(config.version || '3.0');
       origin = config.origin;
     } else {
       this._accessToken = accessTokenOrConfig;

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
@@ -20,7 +20,7 @@ describe('connect', () => {
       MessengerClient.connect(ACCESS_TOKEN);
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v2.11/',
+        baseURL: 'https://graph.facebook.com/v3.0/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -30,7 +30,7 @@ describe('connect', () => {
       MessengerClient.connect({ accessToken: ACCESS_TOKEN });
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v2.11/',
+        baseURL: 'https://graph.facebook.com/v3.0/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -66,7 +66,7 @@ describe('connect', () => {
     });
 
     expect(axios.create).toBeCalledWith({
-      baseURL: 'https://mydummytestserver.com/v2.11/',
+      baseURL: 'https://mydummytestserver.com/v3.0/',
       headers: { 'Content-Type': 'application/json' },
     });
   });
@@ -79,7 +79,7 @@ describe('constructor', () => {
       new MessengerClient(ACCESS_TOKEN); // eslint-disable-line no-new
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v2.11/',
+        baseURL: 'https://graph.facebook.com/v3.0/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -89,7 +89,7 @@ describe('constructor', () => {
       new MessengerClient({ accessToken: ACCESS_TOKEN }); // eslint-disable-line no-new
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v2.11/',
+        baseURL: 'https://graph.facebook.com/v3.0/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -126,7 +126,7 @@ describe('constructor', () => {
     });
 
     expect(axios.create).toBeCalledWith({
-      baseURL: 'https://mydummytestserver.com/v2.11/',
+      baseURL: 'https://mydummytestserver.com/v3.0/',
       headers: { 'Content-Type': 'application/json' },
     });
   });
@@ -134,7 +134,7 @@ describe('constructor', () => {
 
 describe('#version', () => {
   it('should return version of graph api', () => {
-    expect(new MessengerClient(ACCESS_TOKEN).version).toEqual('2.11');
+    expect(new MessengerClient(ACCESS_TOKEN).version).toEqual('3.0');
     expect(new MessengerClient(ACCESS_TOKEN, 'v2.6').version).toEqual('2.6');
     expect(new MessengerClient(ACCESS_TOKEN, '2.6').version).toEqual('2.6');
     expect(() => {
@@ -143,7 +143,7 @@ describe('#version', () => {
     }).toThrow('Type of `version` must be string.');
 
     expect(new MessengerClient({ accessToken: ACCESS_TOKEN }).version).toEqual(
-      '2.11'
+      '3.0'
     );
     expect(
       new MessengerClient({ accessToken: ACCESS_TOKEN, version: 'v2.6' })


### PR DESCRIPTION
https://developers.facebook.com/docs/graph-api/changelog/version3.0#gapi-new

There are no any visible breaking changes between 2.11 and 3.0, so we should just go forward.