### PR TITLE
implement getMessagingFeatureReview

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -3095,6 +3095,24 @@ client.getPageInfo().then(page => {
 });
 ```
 
+## getMessagingFeatureReview
+
+Programmatically check the feature submission status of Page-level Platform features.
+
+Example:
+
+```js
+client.getMessagingFeatureReview().then(data => {
+  console.log(data);
+  // [
+  //   {
+  //     "feature": "subscription_messaging",
+  //     "status": "<pending|rejected|approved|limited>"
+  //   }
+  // ]
+});
+```
+
 ## Test
 
 ### Point requests to your dummy server

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -48,6 +48,7 @@ import type {
   InsightMetric,
   InsightOptions,
   PageInfo,
+  MessagingFeatureReview,
 } from './MessengerTypes';
 
 type Axios = {
@@ -186,6 +187,22 @@ export default class MessengerClient {
         verify_token,
       })
       .then(res => res.data, handleError);
+  }
+
+  /**
+   *  Messaging Feature Review API
+   *
+   *  https://developers.facebook.com/docs/messenger-platform/reference/messaging-feature-review-api
+   */
+  getMessagingFeatureReview({
+    access_token: customAccessToken,
+  }: { access_token?: string } = {}): Promise<Array<MessagingFeatureReview>> {
+    return this._axios
+      .get(
+        `/me/messaging_feature_review?access_token=${customAccessToken ||
+          this._accessToken}`
+      )
+      .then(res => res.data.data, handleError);
   }
 
   /**

--- a/packages/messaging-api-messenger/src/MessengerTypes.js
+++ b/packages/messaging-api-messenger/src/MessengerTypes.js
@@ -364,3 +364,8 @@ export type PageInfo = {
   name: string,
   id: string,
 };
+
+export type MessagingFeatureReview = {
+  feature: string,
+  status: 'pending' | 'rejected' | 'approved' | 'limited',
+};

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
@@ -105,6 +105,33 @@ describe('subscription', () => {
   });
 });
 
+describe('#getMessagingFeatureReview', () => {
+  it('should response feature array', async () => {
+    const { client, mock } = createMock();
+    const reply = {
+      data: [
+        {
+          feature: 'subscription_messaging',
+          status: 'approved',
+        },
+      ],
+    };
+
+    mock
+      .onGet(`/me/messaging_feature_review?access_token=${ACCESS_TOKEN}`)
+      .reply(200, reply);
+
+    const res = await client.getMessagingFeatureReview();
+
+    expect(res).toEqual([
+      {
+        feature: 'subscription_messaging',
+        status: 'approved',
+      },
+    ]);
+  });
+});
+
 describe('user profile', () => {
   describe('#getUserProfile', () => {
     it('should response user profile', async () => {


### PR DESCRIPTION
close #341

## getMessagingFeatureReview

Programmatically check the feature submission status of Page-level Platform features.

Example:

```js
client.getMessagingFeatureReview().then(data => {
  console.log(data);
  // [
  //   {
  //     "feature": "subscription_messaging",
  //     "status": "<pending|rejected|approved|limited>"
  //   }
  // ]
});
```