### PR TITLE
implement scheduling-broadcasts

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -21,6 +21,7 @@
     * [Targeting Broadcast Messages](#targeting-broadcast-messages)
     * [Estimating Broadcast Size](#estimating-broadcast-size)
     * [Broadcast Metrics](#broadcast-metrics)
+    * [Scheduling Broadcasts](#scheduling-broadcasts)
   * [User Profile API](#user-profile-api)
   * [Messenger Profile API](#messenger-profile-api)
     * [Persistent Menu](#persistent-menu)
@@ -1502,12 +1503,13 @@ The following message templates are not supported:
 
 ## `sendBroadcastMessage(messageCreativeId, options)`
 
-| Param                   | Type     | Description                                                                 |
-| ----------------------- | -------- | --------------------------------------------------------------------------- |
-| messageCreativeId       | `Number` | The `message_creative_id` of the message creative to send in the broadcast. |
-| options                 | `Object` | Other optional parameters.                                                  |
-| options.custom_label_id | `Number` | The id of custom label.                                                     |
-| options.targeting       | `Object` | The targeting config.                                                       |
+| Param                   | Type     | Description                                                                                                                                       |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| messageCreativeId       | `Number` | The `message_creative_id` of the message creative to send in the broadcast.                                                                       |
+| options                 | `Object` | Other optional parameters.                                                                                                                        |
+| options.custom_label_id | `Number` | The id of custom label.                                                                                                                           |
+| options.targeting       | `Object` | The targeting config.                                                                                                                             |
+| options.schedule_time   | `String` | ISO-8601 and Unix timestamp formats are accepted. For example 2018-04-05T20:39:13+00:00 and 1522960753 both represent 8:39:13pm 04/05/2018 (UTC). |
 
 Example
 
@@ -1830,6 +1832,63 @@ client.getBroadcastMessagesSent(73450120243).then(result => {
 ```
 
 <br />
+
+<a id="scheduling-broadcasts" />
+
+### Scheduling Broadcasts - [Official Docs](https://developers.facebook.com/docs/messenger-platform/send-messages/broadcast-messages/#scheduling)
+
+To schedule a broadcast, specify the `schedule_time` property when you call the `sendBroadcastMessage` API request to send the message.
+
+```js
+client
+  .sendBroadcastMessage(938461089, {
+    schedule_time: '2018-04-05T20:39:13+00:00',
+  })
+  .then(result => {
+    console.log(result);
+    // {
+    //   broadcast_id: '115517705935329',
+    // }
+  });
+```
+
+## `cancelBroadcast(broadcastId)`
+
+| Param       | Type     | Description       |
+| ----------- | -------- | ----------------- |
+| broadcastId | `String` | The broadcast ID. |
+
+Cancel a scheduled broadcast.
+
+```js
+client.cancelBroadcast('115517705935329');
+```
+
+## `getBroadcast(broadcastId)`
+
+| Param       | Type     | Description       |
+| ----------- | -------- | ----------------- |
+| broadcastId | `String` | The broadcast ID. |
+
+Check on broadcast status.
+
+```js
+client.getBroadcast('115517705935329').then(broadcast => {
+  console.log(broadcast);
+  // {
+  //   scheduled_time: '2018-04-05T20:39:13+00:00',
+  //   status: 'SCHEDULED',
+  //   id: "115517705935329"
+  // }
+});
+```
+
+The API will respond with the time the broadcast is scheduled for, and one of the following statuses:
+
+* `SCHEDULED`: Broadcast is scheduled but has not been sent.
+* `IN_PROGRESS`: Broadcast has been initiated and is still in-progress.
+* `FINISHED`: Broadcast was completed successfully.
+* `CANCELED`: Broadcast was canceled by the developer.
 
 <a id="user-profile-api" />
 

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -1070,6 +1070,27 @@ export default class MessengerClient {
       .then(res => res.data, handleError);
   }
 
+  cancelBroadcast(broadcastId: number, options?: Object = {}) {
+    return this._axios
+      .post(
+        `/${broadcastId}?access_token=${options.access_token ||
+          this._accessToken}`,
+        {
+          operation: 'cancel',
+        }
+      )
+      .then(res => res.data, handleError);
+  }
+
+  getBroadcast(broadcastId: number, options?: Object = {}) {
+    return this._axios
+      .get(
+        `/${broadcastId}?fields=scheduled_time,status&access_token=${options.access_token ||
+          this._accessToken}`
+      )
+      .then(res => res.data, handleError);
+  }
+
   /**
    * Send Sponsored Message
    *

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-broadcast.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-broadcast.spec.js
@@ -175,6 +175,69 @@ describe('broadcast api', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('can send with schedule_time', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {
+        broadcast_id: 837,
+      };
+
+      mock
+        .onPost(`/me/broadcast_messages?access_token=${ACCESS_TOKEN}`, {
+          message_creative_id: 938461089,
+          schedule_time: '2018-04-05T20:39:13+00:00',
+        })
+        .reply(200, reply);
+
+      const res = await client.sendBroadcastMessage(938461089, {
+        schedule_time: '2018-04-05T20:39:13+00:00',
+      });
+
+      expect(res).toEqual(reply);
+    });
+  });
+
+  describe('#cancelBroadcast', () => {
+    it('should call broadcast api with cancel operation', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {
+        success: true,
+      };
+
+      mock
+        .onPost(`/938461089?access_token=${ACCESS_TOKEN}`, {
+          operation: 'cancel',
+        })
+        .reply(200, reply);
+
+      const res = await client.cancelBroadcast(938461089);
+
+      expect(res).toEqual(reply);
+    });
+  });
+
+  describe('#getBroadcast', () => {
+    it('should get broadcast status', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {
+        scheduled_time: '<ISO-8601_FORMAT_TIME>',
+        status: '<STATUS>',
+        id: '<BROADCAST_ID>',
+      };
+
+      mock
+        .onGet(
+          `/938461089?fields=scheduled_time,status&access_token=${ACCESS_TOKEN}`
+        )
+        .reply(200, reply);
+
+      const res = await client.getBroadcast(938461089);
+
+      expect(res).toEqual(reply);
+    });
   });
 
   describe('#sendSponsoredMessage', () => {


### PR DESCRIPTION
close #346

### Scheduling Broadcasts - [Official Docs](https://developers.facebook.com/docs/messenger-platform/send-messages/broadcast-messages/#scheduling)

To schedule a broadcast, specify the `schedule_time` property when you call the `sendBroadcastMessage` API request to send the message.

```js
client
  .sendBroadcastMessage(938461089, {
    schedule_time: '2018-04-05T20:39:13+00:00',
  })
  .then(result => {
    console.log(result);
    // {
    //   broadcast_id: '115517705935329',
    // }
  });
```

## `cancelBroadcast(broadcastId)`

| Param       | Type     | Description       |
| ----------- | -------- | ----------------- |
| broadcastId | `String` | The broadcast ID. |

Cancel a scheduled broadcast.

```js
client.cancelBroadcast('115517705935329');
```

## `getBroadcast(broadcastId)`

| Param       | Type     | Description       |
| ----------- | -------- | ----------------- |
| broadcastId | `String` | The broadcast ID. |

Check on broadcast status.

```js
client.getBroadcast('115517705935329').then(broadcast => {
  console.log(broadcast);
  // {
  //   scheduled_time: '2018-04-05T20:39:13+00:00',
  //   status: 'SCHEDULED',
  //   id: "115517705935329"
  // }
});
```

The API will respond with the time the broadcast is scheduled for, and one of the following statuses:

* `SCHEDULED`: Broadcast is scheduled but has not been sent.
* `IN_PROGRESS`: Broadcast has been initiated and is still in-progress.
* `FINISHED`: Broadcast was completed successfully.
* `CANCELED`: Broadcast was canceled by the developer.