### PR TITLE
add appsecret_proof to all of request if appSecret exists

### DIFF
--- a/packages/messaging-api-messenger/package.json
+++ b/packages/messaging-api-messenger/package.json
@@ -18,6 +18,7 @@
     "messenger"
   ],
   "dependencies": {
+    "append-query": "^2.0.1",
     "axios": "^0.17.0",
     "axios-error": "^0.7.0",
     "form-data": "^2.3.1",

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
@@ -1,6 +1,9 @@
+import MockAdapter from 'axios-mock-adapter';
+
 import MessengerClient from '../MessengerClient';
 
-const ACCESS_TOKEN = '1234567890';
+const ACCESS_TOKEN = 'foo_token';
+const APP_SECRET = 'shhhhh!is.my.secret';
 
 let axios;
 let _create;
@@ -182,5 +185,34 @@ describe('#accessToken', () => {
 
     client = new MessengerClient({ accessToken: ACCESS_TOKEN });
     expect(client.accessToken).toBe(ACCESS_TOKEN);
+  });
+});
+
+describe('appsecret proof', () => {
+  it('should add appsecret proof to requests if appSecret exists', async () => {
+    expect.assertions(1);
+
+    const client = new MessengerClient({
+      accessToken: ACCESS_TOKEN,
+      appSecret: APP_SECRET,
+    });
+
+    const mock = new MockAdapter(client.axios);
+
+    const USER_ID = 'USER_ID';
+
+    const reply = {
+      recipient_id: USER_ID,
+      message_id: 'mid.1489394984387:3dd22de509',
+    };
+
+    mock.onPost().reply(config => {
+      expect(config.url).toBe(
+        'me/messages?access_token=foo_token&appsecret_proof=796ba0d8a6b339e476a7b166a9e8ac0a395f7de736dc37de5f2f4397f5854eb8'
+      );
+      return [200, reply];
+    });
+
+    await client.sendText(USER_ID, 'Hello!');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,6 +219,12 @@ app-root-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
+append-query@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/append-query/-/append-query-2.0.1.tgz#d996a5954c3746b00ced7b36fa1ee2f023642025"
+  dependencies:
+    extend "^1.3.0"
+
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
@@ -1987,6 +1993,10 @@ extend-shallow@^3.0.2:
   dependencies:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
+
+extend@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-1.3.0.tgz#d1516fb0ff5624d2ebf9123ea1dac5a1994004f8"
 
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"


### PR DESCRIPTION
close #355

then `MessengerConnector` can pass `appSecret` down to `MessengerClient` here

https://github.com/Yoctol/bottender/blob/ddbc948f8883b9aba4e08b1dbb56339ced5da864/src/bot/MessengerConnector.js#L103

- [x] need test

reference: https://github.com/facebook/php-graph-sdk/blob/2f9639c15ae043911f40ffe44080b32bac2c5280/tests/Authentication/AccessTokenTest.php#L39-L46