### PR TITLE
use lodash get to get error info

### DIFF
--- a/packages/messaging-api-messenger/package.json
+++ b/packages/messaging-api-messenger/package.json
@@ -25,6 +25,7 @@
     "form-data": "^2.3.2",
     "invariant": "^2.2.4",
     "is-plain-object": "^2.0.4",
+    "lodash.get": "^4.4.2",
     "lodash.omit": "^4.5.0",
     "warning": "^4.0.1"
   },

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -9,6 +9,7 @@ import AxiosError from 'axios-error';
 import FormData from 'form-data';
 import invariant from 'invariant';
 import warning from 'warning';
+import get from 'lodash.get';
 import omit from 'lodash.omit';
 import isPlainObject from 'is-plain-object';
 import appendQuery from 'append-query';
@@ -69,7 +70,7 @@ function extractVersion(version) {
 
 function handleError(err) {
   if (err.response && err.response.data) {
-    const { error } = err.response.data;
+    const error = get(err, 'response.data.error', {});
     const msg = `Messenger API - ${error.code} ${error.type} ${error.message}`;
     throw new AxiosError(msg, err);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3712,6 +3712,10 @@ lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.omit@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"


### PR DESCRIPTION
prevent something like

```
TypeError: Cannot read property 'code' of undefined
    at handleError (/app/node_modules/messaging-api-messenger/lib/MessengerClient.js:73:42)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```