### PR TITLE
LINE: add apis for default rich menu

### DIFF
--- a/packages/messaging-api-line/README.md
+++ b/packages/messaging-api-line/README.md
@@ -2299,6 +2299,53 @@ client.uploadRichMenuImage(RICH_MENU_ID, fs.readFileSync('image.png'));
 
 <br />
 
+## `getDefaultRichMenu()` - [Official Docs](https://developers.line.me/en/reference/messaging-api/#get-default-rich-menu-id)
+
+Gets the ID of the default rich menu set with the Messaging API.
+
+Example:
+
+```js
+client.getDefaultRichMenu().then(richMenu => {
+  console.log(richMenu);
+  // {
+  //   "richMenuId": "{richMenuId}"
+  // }
+});
+```
+
+<br />
+
+## `setDefaultRichMenu(richMenuId)` - [Official Docs](https://developers.line.me/en/reference/messaging-api/#set-default-rich-menu)
+
+Sets the default rich menu. The default rich menu is displayed to all users who have added your bot as a friend and are not linked to any per-user rich menu.
+
+| Param      | Type     | Description                  |
+| ---------- | -------- | ---------------------------- |
+| richMenuId | `String` | ID of an uploaded rich menu. |
+
+Example:
+
+```js
+client.setDefaultRichMenu('{richMenuId}');
+```
+
+> The rich menu is displayed in the following order of priority (highest to lowest): The per-user rich menu set with the Messaging API, the default rich menu set with the Messaging API, and the default rich menu set with LINE@ Manager.
+
+<br />
+
+## `deleteDefaultRichMenu()` - [Official Docs](https://developers.line.me/en/reference/messaging-api/#cancel-default-rich-menu)
+
+Cancels the default rich menu set with the Messaging API.
+
+Example:
+
+```js
+client.deleteDefaultRichMenu();
+```
+
+<br />
+
 <a id="account-link-api" />
 
 ### Account Link API - [Official Docs](https://developers.line.me/en/docs/messaging-api/reference/#account-link)

--- a/packages/messaging-api-line/src/LineClient.js
+++ b/packages/messaging-api-line/src/LineClient.js
@@ -643,6 +643,24 @@ export default class LineClient {
       .then(res => res.data, handleError);
   }
 
+  getDefaultRichMenu() {
+    return this._axios
+      .get(`/v2/bot/user/all/richmenu`)
+      .then(res => res.data, handleError);
+  }
+
+  setDefaultRichMenu(richMenuId: string) {
+    return this._axios
+      .post(`/v2/bot/user/all/richmenu/${richMenuId}`)
+      .then(res => res.data, handleError);
+  }
+
+  deleteDefaultRichMenu() {
+    return this._axios
+      .delete(`/v2/bot/user/all/richmenu`)
+      .then(res => res.data, handleError);
+  }
+
   /**
    * - Images must have one of the following resolutions: 2500x1686, 2500x843.
    * - You cannot replace an image attached to a rich menu.

--- a/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.js
@@ -276,4 +276,54 @@ describe('Rich Menu', () => {
       expect(res).toEqual(reply);
     });
   });
+
+  describe('#getDefaultRichMenu', () => {
+    it('should call api', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {
+        richMenuId: 'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5',
+      };
+
+      mock.onGet('/v2/bot/user/all/richmenu').reply(200, reply, headers);
+
+      const res = await client.getDefaultRichMenu();
+
+      expect(res).toEqual(reply);
+    });
+  });
+
+  describe('#setDefaultRichMenu', () => {
+    it('should call api', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock
+        .onPost(
+          '/v2/bot/user/all/richmenu/richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'
+        )
+        .reply(200, reply, headers);
+
+      const res = await client.setDefaultRichMenu(
+        'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'
+      );
+
+      expect(res).toEqual(reply);
+    });
+  });
+
+  describe('#deleteDefaultRichMenu', () => {
+    it('should call api', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {};
+
+      mock.onDelete('/v2/bot/user/all/richmenu').reply(200, reply, headers);
+
+      const res = await client.deleteDefaultRichMenu();
+
+      expect(res).toEqual(reply);
+    });
+  });
 });


### PR DESCRIPTION
## `getDefaultRichMenu()` - [Official Docs](https://developers.line.me/en/reference/messaging-api/#get-default-rich-menu-id)

Gets the ID of the default rich menu set with the Messaging API.

Example:

```js
client.getDefaultRichMenu().then(richMenu => {
  console.log(richMenu);
  // {
  //   "richMenuId": "{richMenuId}"
  // }
});
```

<br />

## `setDefaultRichMenu(richMenuId)` - [Official Docs](https://developers.line.me/en/reference/messaging-api/#set-default-rich-menu)

Sets the default rich menu. The default rich menu is displayed to all users who have added your bot as a friend and are not linked to any per-user rich menu.

| Param      | Type     | Description                  |
| ---------- | -------- | ---------------------------- |
| richMenuId | `String` | ID of an uploaded rich menu. |

Example:

```js
client.setDefaultRichMenu('{richMenuId}');
```

> The rich menu is displayed in the following order of priority (highest to lowest): The per-user rich menu set with the Messaging API, the default rich menu set with the Messaging API, and the default rich menu set with LINE@ Manager.

<br />

## `deleteDefaultRichMenu()` - [Official Docs](https://developers.line.me/en/reference/messaging-api/#cancel-default-rich-menu)

Cancels the default rich menu set with the Messaging API.

Example:

```js
client.deleteDefaultRichMenu();
```


close #397