### PR TITLE
add option: skipAppSecretProof

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
     "transformIgnorePatterns": [
       "/node_modules/"
     ],
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "timers": "fake",
+    "resetMocks": true
   },
   "lint-staged": {
     "*.js": [

--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -90,6 +90,16 @@ const client = MessengerClient.connect({
 });
 ```
 
+To skip it, set `skipAppSecretProof` to `true`:
+
+```js
+const client = MessengerClient.connect({
+  accessToken: ACCESS_TOKEN,
+  appSecret: APP_SECRET,
+  skipAppSecretProof: true,
+});
+```
+
 ### Error Handling
 
 `messaging-api-messenger` uses [axios](https://github.com/axios/axios) as HTTP client. We use [axios-error](https://github.com/Yoctol/messaging-apis/tree/master/packages/axios-error) package to wrap API error instances for better formatting error messages. Directly `console.log` on the error instance will return formatted message. If you'd like to get the axios `request`, `response`, or `config`, you can still get them via those keys on the error instance.

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
@@ -316,4 +316,30 @@ describe('appsecret proof', () => {
 
     await client.sendText(USER_ID, 'Hello!');
   });
+
+  it('should not add appsecret proof to requests if skipAppSecretProof: true', async () => {
+    expect.assertions(1);
+
+    const client = new MessengerClient({
+      accessToken: ACCESS_TOKEN,
+      appSecret: APP_SECRET,
+      skipAppSecretProof: true,
+    });
+
+    const mock = new MockAdapter(client.axios);
+
+    const USER_ID = 'USER_ID';
+
+    const reply = {
+      recipient_id: USER_ID,
+      message_id: 'mid.1489394984387:3dd22de509',
+    };
+
+    mock.onPost().reply(config => {
+      expect(config.url).toBe('me/messages?access_token=foo_token');
+      return [200, reply];
+    });
+
+    await client.sendText(USER_ID, 'Hello!');
+  });
 });


### PR DESCRIPTION
To avoid adding `appsecret_proof`, set `skipAppSecretProof` to `true`:

```js
const client = MessengerClient.connect({
  accessToken: ACCESS_TOKEN,
  appSecret: APP_SECRET,
  skipAppSecretProof: true,
});
```