### PR TITLE
fix line client tests with axios headers

### DIFF
--- a/packages/messaging-api-line/src/__tests__/LineClient-liff.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-liff.spec.js
@@ -6,6 +6,8 @@ const ACCESS_TOKEN = '1234567890';
 const CHANNEL_SECRET = 'so-secret';
 
 const headers = {
+  Accept: 'application/json, text/plain, */*',
+  'Content-Type': 'application/json',
   Authorization: `Bearer ${ACCESS_TOKEN}`,
 };
 
@@ -39,7 +41,7 @@ describe('LINE Front-end Framework', () => {
         ],
       };
 
-      mock.onGet('/liff/v1/apps').reply(200, reply, headers);
+      mock.onGet('/liff/v1/apps', undefined, headers).reply(200, reply);
 
       const res = await client.getLiffAppList();
 
@@ -71,11 +73,16 @@ describe('LINE Front-end Framework', () => {
       };
 
       mock
-        .onPost('/liff/v1/apps', {
-          type: 'tall',
-          url: 'https://example.com/myservice',
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/liff/v1/apps',
+          {
+            type: 'tall',
+            url: 'https://example.com/myservice',
+          },
+
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.createLiffApp({
         type: 'tall',
@@ -95,11 +102,16 @@ describe('LINE Front-end Framework', () => {
       const reply = {};
 
       mock
-        .onPut('/liff/v1/apps/liff-12345/view', {
-          type: 'tall',
-          url: 'https://example.com/myservice',
-        })
-        .reply(200, reply, headers);
+        .onPut(
+          '/liff/v1/apps/liff-12345/view',
+          {
+            type: 'tall',
+            url: 'https://example.com/myservice',
+          },
+          undefined,
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.updateLiffApp('liff-12345', {
         type: 'tall',
@@ -116,7 +128,9 @@ describe('LINE Front-end Framework', () => {
 
       const reply = {};
 
-      mock.onDelete('/liff/v1/apps/liff-12345').reply(200, reply, headers);
+      mock
+        .onDelete('/liff/v1/apps/liff-12345', undefined, headers)
+        .reply(200, reply);
 
       const res = await client.deleteLiffApp('liff-12345');
 

--- a/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.js
@@ -9,6 +9,8 @@ const ACCESS_TOKEN = '1234567890';
 const CHANNEL_SECRET = 'so-secret';
 
 const headers = {
+  Accept: 'application/json, text/plain, */*',
+  'Content-Type': 'application/json',
   Authorization: `Bearer ${ACCESS_TOKEN}`,
 };
 
@@ -52,7 +54,7 @@ describe('Rich Menu', () => {
         ],
       };
 
-      mock.onGet('/v2/bot/richmenu/list').reply(200, reply, headers);
+      mock.onGet('/v2/bot/richmenu/list', undefined, headers).reply(200, reply);
 
       const res = await client.getRichMenuList();
 
@@ -115,8 +117,12 @@ describe('Rich Menu', () => {
       };
 
       mock
-        .onGet('/v2/bot/richmenu/richmenu-8dfdfc571eca39c0ffcd1f799519c5b5')
-        .reply(200, reply, headers);
+        .onGet(
+          '/v2/bot/richmenu/richmenu-8dfdfc571eca39c0ffcd1f799519c5b5',
+          undefined,
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.getRichMenu(
         'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'
@@ -134,7 +140,7 @@ describe('Rich Menu', () => {
         richMenuId: 'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5',
       };
 
-      mock.onPost('/v2/bot/richmenu').reply(200, reply, headers);
+      mock.onPost('/v2/bot/richmenu', undefined, headers).reply(200, reply);
 
       const res = await client.createRichMenu({
         size: {
@@ -170,7 +176,7 @@ describe('Rich Menu', () => {
 
       const reply = {};
 
-      mock.onDelete('/v2/bot/richmenu/1').reply(200, reply, headers);
+      mock.onDelete('/v2/bot/richmenu/1', undefined, headers).reply(200, reply);
 
       const res = await client.deleteRichMenu('1');
 
@@ -186,7 +192,9 @@ describe('Rich Menu', () => {
         richMenuId: 'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5',
       };
 
-      mock.onGet('/v2/bot/user/1/richmenu').reply(200, reply, headers);
+      mock
+        .onGet('/v2/bot/user/1/richmenu', undefined, headers)
+        .reply(200, reply);
 
       const res = await client.getLinkedRichMenu('1');
 
@@ -200,7 +208,9 @@ describe('Rich Menu', () => {
 
       const reply = {};
 
-      mock.onPost('/v2/bot/user/1/richmenu/2').reply(200, reply, headers);
+      mock
+        .onPost('/v2/bot/user/1/richmenu/2', undefined, headers)
+        .reply(200, reply);
 
       const res = await client.linkRichMenu('1', '2');
 
@@ -214,7 +224,9 @@ describe('Rich Menu', () => {
 
       const reply = {};
 
-      mock.onDelete('/v2/bot/user/1/richmenu').reply(200, reply, headers);
+      mock
+        .onDelete('/v2/bot/user/1/richmenu', undefined, headers)
+        .reply(200, reply);
 
       const res = await client.unlinkRichMenu('1');
 
@@ -228,7 +240,12 @@ describe('Rich Menu', () => {
 
       const reply = {};
 
-      mock.onPost('/v2/bot/richmenu/1/content').reply(200, reply);
+      mock
+        .onPost('/v2/bot/richmenu/1/content', undefined, {
+          ...headers,
+          'Content-Type': 'image/png',
+        })
+        .reply(200, reply);
 
       const buffer = await new Promise((resolve, reject) => {
         fs.readFile(path.join(__dirname, 'fixture.png'), (err, buf) => {
@@ -250,7 +267,9 @@ describe('Rich Menu', () => {
 
       const reply = {};
 
-      mock.onPost('/v2/bot/richmenu/1/content').reply(200, reply);
+      mock
+        .onPost('/v2/bot/richmenu/1/content', undefined, headers)
+        .reply(200, reply);
 
       let error;
       try {
@@ -269,7 +288,9 @@ describe('Rich Menu', () => {
 
       const reply = Buffer.from('a content buffer');
 
-      mock.onGet('/v2/bot/richmenu/1/content').reply(200, reply);
+      mock
+        .onGet('/v2/bot/richmenu/1/content', undefined, headers)
+        .reply(200, reply);
 
       const res = await client.downloadRichMenuImage('1');
 
@@ -285,7 +306,9 @@ describe('Rich Menu', () => {
         richMenuId: 'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5',
       };
 
-      mock.onGet('/v2/bot/user/all/richmenu').reply(200, reply, headers);
+      mock
+        .onGet('/v2/bot/user/all/richmenu', undefined, headers)
+        .reply(200, reply);
 
       const res = await client.getDefaultRichMenu();
 
@@ -301,9 +324,11 @@ describe('Rich Menu', () => {
 
       mock
         .onPost(
-          '/v2/bot/user/all/richmenu/richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'
+          '/v2/bot/user/all/richmenu/richmenu-8dfdfc571eca39c0ffcd1f799519c5b5',
+          undefined,
+          headers
         )
-        .reply(200, reply, headers);
+        .reply(200, reply);
 
       const res = await client.setDefaultRichMenu(
         'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'
@@ -319,7 +344,9 @@ describe('Rich Menu', () => {
 
       const reply = {};
 
-      mock.onDelete('/v2/bot/user/all/richmenu').reply(200, reply, headers);
+      mock
+        .onDelete('/v2/bot/user/all/richmenu', undefined, headers)
+        .reply(200, reply);
 
       const res = await client.deleteDefaultRichMenu();
 

--- a/packages/messaging-api-line/src/__tests__/LineClient-multicast.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-multicast.spec.js
@@ -7,6 +7,8 @@ const ACCESS_TOKEN = '1234567890';
 const CHANNEL_SECRET = 'so-secret';
 
 const headers = {
+  Accept: 'application/json, text/plain, */*',
+  'Content-Type': 'application/json',
   Authorization: `Bearer ${ACCESS_TOKEN}`,
 };
 
@@ -24,11 +26,15 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [{ type: 'text', text: 'Hello!' }],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [{ type: 'text', text: 'Hello!' }],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastRawBody({
         to: [RECIPIENT_ID],
@@ -51,11 +57,15 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [{ type: 'text', text: 'Hello!' }],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [{ type: 'text', text: 'Hello!' }],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicast(
         [RECIPIENT_ID],
@@ -78,11 +88,15 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [{ type: 'text', text: 'Hello!' }],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [{ type: 'text', text: 'Hello!' }],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastText([RECIPIENT_ID], 'Hello!');
 
@@ -97,17 +111,21 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'image',
-              originalContentUrl: 'https://example.com/original.jpg',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'image',
+                originalContentUrl: 'https://example.com/original.jpg',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastImage(
         [RECIPIENT_ID],
@@ -124,17 +142,21 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'image',
-              originalContentUrl: 'https://example.com/original.jpg',
-              previewImageUrl: 'https://example.com/original.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'image',
+                originalContentUrl: 'https://example.com/original.jpg',
+                previewImageUrl: 'https://example.com/original.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastImage(
         [RECIPIENT_ID],
@@ -150,17 +172,21 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'image',
-              originalContentUrl: 'https://example.com/original.jpg',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'image',
+                originalContentUrl: 'https://example.com/original.jpg',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastImage([RECIPIENT_ID], {
         originalContentUrl: 'https://example.com/original.jpg',
@@ -178,17 +204,21 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'video',
-              originalContentUrl: 'https://example.com/original.mp4',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'video',
+                originalContentUrl: 'https://example.com/original.mp4',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastVideo(
         [RECIPIENT_ID],
@@ -205,17 +235,21 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'video',
-              originalContentUrl: 'https://example.com/original.mp4',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'video',
+                originalContentUrl: 'https://example.com/original.mp4',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastVideo([RECIPIENT_ID], {
         originalContentUrl: 'https://example.com/original.mp4',
@@ -233,17 +267,21 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'audio',
-              originalContentUrl: 'https://example.com/original.m4a',
-              duration: 240000,
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'audio',
+                originalContentUrl: 'https://example.com/original.m4a',
+                duration: 240000,
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastAudio(
         [RECIPIENT_ID],
@@ -260,17 +298,21 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'audio',
-              originalContentUrl: 'https://example.com/original.m4a',
-              duration: 240000,
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'audio',
+                originalContentUrl: 'https://example.com/original.m4a',
+                duration: 240000,
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastAudio([RECIPIENT_ID], {
         originalContentUrl: 'https://example.com/original.m4a',
@@ -288,19 +330,23 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'location',
-              title: 'my location',
-              address: '〒150-0002 東京都渋谷区渋谷２丁目２１−１',
-              latitude: 35.65910807942215,
-              longitude: 139.70372892916203,
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'location',
+                title: 'my location',
+                address: '〒150-0002 東京都渋谷区渋谷２丁目２１−１',
+                latitude: 35.65910807942215,
+                longitude: 139.70372892916203,
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastLocation([RECIPIENT_ID], {
         title: 'my location',
@@ -320,17 +366,21 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'sticker',
-              packageId: '1',
-              stickerId: '1',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'sticker',
+                packageId: '1',
+                stickerId: '1',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastSticker([RECIPIENT_ID], '1', '1');
 
@@ -343,17 +393,21 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'sticker',
-              packageId: '1',
-              stickerId: '1',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'sticker',
+                packageId: '1',
+                stickerId: '1',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastSticker([RECIPIENT_ID], {
         packageId: '1',
@@ -371,43 +425,47 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'imagemap',
-              baseUrl: 'https://example.com/bot/images/rm001',
-              altText: 'this is an imagemap',
-              baseSize: {
-                height: 1040,
-                width: 1040,
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'imagemap',
+                baseUrl: 'https://example.com/bot/images/rm001',
+                altText: 'this is an imagemap',
+                baseSize: {
+                  height: 1040,
+                  width: 1040,
+                },
+                actions: [
+                  {
+                    type: 'uri',
+                    linkUri: 'https://example.com/',
+                    area: {
+                      x: 0,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                  {
+                    type: 'message',
+                    text: 'hello',
+                    area: {
+                      x: 520,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                ],
               },
-              actions: [
-                {
-                  type: 'uri',
-                  linkUri: 'https://example.com/',
-                  area: {
-                    x: 0,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-                {
-                  type: 'message',
-                  text: 'hello',
-                  area: {
-                    x: 520,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-              ],
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastImagemap(
         [RECIPIENT_ID],
@@ -450,43 +508,47 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'imagemap',
-              baseUrl: 'https://example.com/bot/images/rm001',
-              altText: 'this is an imagemap',
-              baseSize: {
-                height: 1040,
-                width: 1040,
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'imagemap',
+                baseUrl: 'https://example.com/bot/images/rm001',
+                altText: 'this is an imagemap',
+                baseSize: {
+                  height: 1040,
+                  width: 1040,
+                },
+                actions: [
+                  {
+                    type: 'uri',
+                    linkUri: 'https://example.com/',
+                    area: {
+                      x: 0,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                  {
+                    type: 'message',
+                    text: 'hello',
+                    area: {
+                      x: 520,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                ],
               },
-              actions: [
-                {
-                  type: 'uri',
-                  linkUri: 'https://example.com/',
-                  area: {
-                    x: 0,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-                {
-                  type: 'message',
-                  text: 'hello',
-                  area: {
-                    x: 520,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-              ],
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastImagemap(
         [RECIPIENT_ID],
@@ -531,57 +593,61 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'imagemap',
-              baseUrl: 'https://example.com/bot/images/rm001',
-              altText: 'this is an imagemap',
-              baseSize: {
-                height: 1040,
-                width: 1040,
-              },
-              video: {
-                originalContentUrl: 'https://example.com/video.mp4',
-                previewImageUrl: 'https://example.com/video_preview.jpg',
-                area: {
-                  x: 0,
-                  y: 0,
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'imagemap',
+                baseUrl: 'https://example.com/bot/images/rm001',
+                altText: 'this is an imagemap',
+                baseSize: {
+                  height: 1040,
                   width: 1040,
-                  height: 585,
                 },
-                externalLink: {
-                  linkUri: 'https://example.com/see_more.html',
-                  label: 'See More',
-                },
-              },
-              actions: [
-                {
-                  type: 'uri',
-                  linkUri: 'https://example.com/',
+                video: {
+                  originalContentUrl: 'https://example.com/video.mp4',
+                  previewImageUrl: 'https://example.com/video_preview.jpg',
                   area: {
                     x: 0,
                     y: 0,
-                    width: 520,
-                    height: 1040,
+                    width: 1040,
+                    height: 585,
+                  },
+                  externalLink: {
+                    linkUri: 'https://example.com/see_more.html',
+                    label: 'See More',
                   },
                 },
-                {
-                  type: 'message',
-                  text: 'hello',
-                  area: {
-                    x: 520,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
+                actions: [
+                  {
+                    type: 'uri',
+                    linkUri: 'https://example.com/',
+                    area: {
+                      x: 0,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
                   },
-                },
-              ],
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+                  {
+                    type: 'message',
+                    text: 'hello',
+                    area: {
+                      x: 520,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastImagemap(
         [RECIPIENT_ID],
@@ -642,39 +708,43 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a template',
-              template: {
-                type: 'buttons',
-                thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
-                title: 'Menu',
-                text: 'Please select',
-                actions: [
-                  {
-                    type: 'postback',
-                    label: 'Buy',
-                    data: 'action=buy&itemid=123',
-                  },
-                  {
-                    type: 'postback',
-                    label: 'Add to cart',
-                    data: 'action=add&itemid=123',
-                  },
-                  {
-                    type: 'uri',
-                    label: 'View detail',
-                    uri: 'http://example.com/page/123',
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a template',
+                template: {
+                  type: 'buttons',
+                  thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+                  title: 'Menu',
+                  text: 'Please select',
+                  actions: [
+                    {
+                      type: 'postback',
+                      label: 'Buy',
+                      data: 'action=buy&itemid=123',
+                    },
+                    {
+                      type: 'postback',
+                      label: 'Add to cart',
+                      data: 'action=add&itemid=123',
+                    },
+                    {
+                      type: 'uri',
+                      label: 'View detail',
+                      uri: 'http://example.com/page/123',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastTemplate(
         [RECIPIENT_ID],
@@ -715,47 +785,51 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a template',
-              template: {
-                type: 'buttons',
-                thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
-                imageAspectRatio: 'rectangle',
-                imageSize: 'cover',
-                imageBackgroundColor: '#FFFFFF',
-                title: 'Menu',
-                text: 'Please select',
-                defaultAction: {
-                  type: 'uri',
-                  label: 'View detail',
-                  uri: 'http://example.com/page/123',
-                },
-                actions: [
-                  {
-                    type: 'postback',
-                    label: 'Buy',
-                    data: 'action=buy&itemid=123',
-                  },
-                  {
-                    type: 'postback',
-                    label: 'Add to cart',
-                    data: 'action=add&itemid=123',
-                  },
-                  {
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a template',
+                template: {
+                  type: 'buttons',
+                  thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+                  imageAspectRatio: 'rectangle',
+                  imageSize: 'cover',
+                  imageBackgroundColor: '#FFFFFF',
+                  title: 'Menu',
+                  text: 'Please select',
+                  defaultAction: {
                     type: 'uri',
                     label: 'View detail',
                     uri: 'http://example.com/page/123',
                   },
-                ],
+                  actions: [
+                    {
+                      type: 'postback',
+                      label: 'Buy',
+                      data: 'action=buy&itemid=123',
+                    },
+                    {
+                      type: 'postback',
+                      label: 'Add to cart',
+                      data: 'action=add&itemid=123',
+                    },
+                    {
+                      type: 'uri',
+                      label: 'View detail',
+                      uri: 'http://example.com/page/123',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastButtonTemplate(
         [RECIPIENT_ID],
@@ -803,32 +877,36 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a confirm template',
-              template: {
-                type: 'confirm',
-                text: 'Are you sure?',
-                actions: [
-                  {
-                    type: 'message',
-                    label: 'Yes',
-                    text: 'yes',
-                  },
-                  {
-                    type: 'message',
-                    label: 'No',
-                    text: 'no',
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a confirm template',
+                template: {
+                  type: 'confirm',
+                  text: 'Are you sure?',
+                  actions: [
+                    {
+                      type: 'message',
+                      label: 'Yes',
+                      text: 'yes',
+                    },
+                    {
+                      type: 'message',
+                      label: 'No',
+                      text: 'no',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastConfirmTemplate(
         [RECIPIENT_ID],
@@ -861,69 +939,73 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a carousel template',
-              template: {
-                type: 'carousel',
-                imageAspectRatio: 'rectangle',
-                imageSize: 'cover',
-                columns: [
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item1.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=111',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=111',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/111',
-                      },
-                    ],
-                  },
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item2.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=222',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=222',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/222',
-                      },
-                    ],
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a carousel template',
+                template: {
+                  type: 'carousel',
+                  imageAspectRatio: 'rectangle',
+                  imageSize: 'cover',
+                  columns: [
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item1.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=111',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=111',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/111',
+                        },
+                      ],
+                    },
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item2.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=222',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=222',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/222',
+                        },
+                      ],
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastCarouselTemplate(
         [RECIPIENT_ID],
@@ -989,67 +1071,71 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a carousel template',
-              template: {
-                type: 'carousel',
-                columns: [
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item1.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=111',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=111',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/111',
-                      },
-                    ],
-                  },
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item2.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=222',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=222',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/222',
-                      },
-                    ],
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a carousel template',
+                template: {
+                  type: 'carousel',
+                  columns: [
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item1.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=111',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=111',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/111',
+                        },
+                      ],
+                    },
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item2.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=222',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=222',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/222',
+                        },
+                      ],
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastCarouselTemplate(
         [RECIPIENT_ID],
@@ -1113,45 +1199,49 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is an image carousel template',
-              template: {
-                type: 'image_carousel',
-                columns: [
-                  {
-                    imageUrl: 'https://example.com/bot/images/item1.jpg',
-                    action: {
-                      type: 'postback',
-                      label: 'Buy',
-                      data: 'action=buy&itemid=111',
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is an image carousel template',
+                template: {
+                  type: 'image_carousel',
+                  columns: [
+                    {
+                      imageUrl: 'https://example.com/bot/images/item1.jpg',
+                      action: {
+                        type: 'postback',
+                        label: 'Buy',
+                        data: 'action=buy&itemid=111',
+                      },
                     },
-                  },
-                  {
-                    imageUrl: 'https://example.com/bot/images/item2.jpg',
-                    action: {
-                      type: 'message',
-                      label: 'Yes',
-                      text: 'yes',
+                    {
+                      imageUrl: 'https://example.com/bot/images/item2.jpg',
+                      action: {
+                        type: 'message',
+                        label: 'Yes',
+                        text: 'yes',
+                      },
                     },
-                  },
-                  {
-                    imageUrl: 'https://example.com/bot/images/item3.jpg',
-                    action: {
-                      type: 'uri',
-                      label: 'View detail',
-                      uri: 'http://example.com/page/222',
+                    {
+                      imageUrl: 'https://example.com/bot/images/item3.jpg',
+                      action: {
+                        type: 'uri',
+                        label: 'View detail',
+                        uri: 'http://example.com/page/222',
+                      },
                     },
-                  },
-                ],
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastImageCarouselTemplate(
         [RECIPIENT_ID],
@@ -1195,56 +1285,60 @@ describe('Multicast', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/multicast', {
-          to: [RECIPIENT_ID],
-          messages: [
-            {
-              type: 'flex',
-              altText: 'this is a flex message',
-              contents: {
-                type: 'bubble',
-                header: {
-                  type: 'box',
-                  layout: 'vertical',
-                  contents: [
-                    {
-                      type: 'text',
-                      text: 'Header text',
-                    },
-                  ],
-                },
-                hero: {
-                  type: 'image',
-                  url: 'https://example.com/flex/images/image.jpg',
-                },
-                body: {
-                  type: 'box',
-                  layout: 'vertical',
-                  contents: [
-                    {
-                      type: 'text',
-                      text: 'Body text',
-                    },
-                  ],
-                },
-                footer: {
-                  type: 'box',
-                  layout: 'vertical',
-                  contents: [
-                    {
-                      type: 'text',
-                      text: 'Footer text',
-                    },
-                  ],
-                },
-                styles: {
-                  comment: 'See the example of a bubble style object',
+        .onPost(
+          '/v2/bot/message/multicast',
+          {
+            to: [RECIPIENT_ID],
+            messages: [
+              {
+                type: 'flex',
+                altText: 'this is a flex message',
+                contents: {
+                  type: 'bubble',
+                  header: {
+                    type: 'box',
+                    layout: 'vertical',
+                    contents: [
+                      {
+                        type: 'text',
+                        text: 'Header text',
+                      },
+                    ],
+                  },
+                  hero: {
+                    type: 'image',
+                    url: 'https://example.com/flex/images/image.jpg',
+                  },
+                  body: {
+                    type: 'box',
+                    layout: 'vertical',
+                    contents: [
+                      {
+                        type: 'text',
+                        text: 'Body text',
+                      },
+                    ],
+                  },
+                  footer: {
+                    type: 'box',
+                    layout: 'vertical',
+                    contents: [
+                      {
+                        type: 'text',
+                        text: 'Footer text',
+                      },
+                    ],
+                  },
+                  styles: {
+                    comment: 'See the example of a bubble style object',
+                  },
                 },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.multicastFlex(
         [RECIPIENT_ID],

--- a/packages/messaging-api-line/src/__tests__/LineClient-push.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-push.spec.js
@@ -7,6 +7,8 @@ const ACCESS_TOKEN = '1234567890';
 const CHANNEL_SECRET = 'so-secret';
 
 const headers = {
+  Accept: 'application/json, text/plain, */*',
+  'Content-Type': 'application/json',
   Authorization: `Bearer ${ACCESS_TOKEN}`,
 };
 
@@ -24,11 +26,15 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [{ type: 'text', text: 'Hello!' }],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [{ type: 'text', text: 'Hello!' }],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushRawBody({
         to: RECIPIENT_ID,
@@ -51,11 +57,15 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [{ type: 'text', text: 'Hello!' }],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [{ type: 'text', text: 'Hello!' }],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.push(RECIPIENT_ID, [
         {
@@ -75,11 +85,15 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [{ type: 'text', text: 'Hello!' }],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [{ type: 'text', text: 'Hello!' }],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushText(RECIPIENT_ID, 'Hello!');
 
@@ -94,17 +108,21 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'image',
-              originalContentUrl: 'https://example.com/original.jpg',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'image',
+                originalContentUrl: 'https://example.com/original.jpg',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushImage(
         RECIPIENT_ID,
@@ -121,17 +139,21 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'image',
-              originalContentUrl: 'https://example.com/original.jpg',
-              previewImageUrl: 'https://example.com/original.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'image',
+                originalContentUrl: 'https://example.com/original.jpg',
+                previewImageUrl: 'https://example.com/original.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushImage(
         RECIPIENT_ID,
@@ -147,17 +169,21 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'image',
-              originalContentUrl: 'https://example.com/original.jpg',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'image',
+                originalContentUrl: 'https://example.com/original.jpg',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushImage(RECIPIENT_ID, {
         originalContentUrl: 'https://example.com/original.jpg',
@@ -175,17 +201,21 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'video',
-              originalContentUrl: 'https://example.com/original.mp4',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'video',
+                originalContentUrl: 'https://example.com/original.mp4',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushVideo(
         RECIPIENT_ID,
@@ -202,17 +232,21 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'video',
-              originalContentUrl: 'https://example.com/original.mp4',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'video',
+                originalContentUrl: 'https://example.com/original.mp4',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushVideo(RECIPIENT_ID, {
         originalContentUrl: 'https://example.com/original.mp4',
@@ -230,17 +264,21 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'audio',
-              originalContentUrl: 'https://example.com/original.m4a',
-              duration: 240000,
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'audio',
+                originalContentUrl: 'https://example.com/original.m4a',
+                duration: 240000,
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushAudio(
         RECIPIENT_ID,
@@ -257,17 +295,21 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'audio',
-              originalContentUrl: 'https://example.com/original.m4a',
-              duration: 240000,
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'audio',
+                originalContentUrl: 'https://example.com/original.m4a',
+                duration: 240000,
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushAudio(RECIPIENT_ID, {
         originalContentUrl: 'https://example.com/original.m4a',
@@ -285,19 +327,23 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'location',
-              title: 'my location',
-              address: '〒150-0002 東京都渋谷区渋谷２丁目２１−１',
-              latitude: 35.65910807942215,
-              longitude: 139.70372892916203,
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'location',
+                title: 'my location',
+                address: '〒150-0002 東京都渋谷区渋谷２丁目２１−１',
+                latitude: 35.65910807942215,
+                longitude: 139.70372892916203,
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushLocation(RECIPIENT_ID, {
         title: 'my location',
@@ -317,17 +363,21 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'sticker',
-              packageId: '1',
-              stickerId: '1',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'sticker',
+                packageId: '1',
+                stickerId: '1',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushSticker(RECIPIENT_ID, '1', '1');
 
@@ -340,17 +390,21 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'sticker',
-              packageId: '1',
-              stickerId: '1',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'sticker',
+                packageId: '1',
+                stickerId: '1',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushSticker(RECIPIENT_ID, {
         packageId: '1',
@@ -368,43 +422,47 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'imagemap',
-              baseUrl: 'https://example.com/bot/images/rm001',
-              altText: 'this is an imagemap',
-              baseSize: {
-                height: 1040,
-                width: 1040,
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'imagemap',
+                baseUrl: 'https://example.com/bot/images/rm001',
+                altText: 'this is an imagemap',
+                baseSize: {
+                  height: 1040,
+                  width: 1040,
+                },
+                actions: [
+                  {
+                    type: 'uri',
+                    linkUri: 'https://example.com/',
+                    area: {
+                      x: 0,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                  {
+                    type: 'message',
+                    text: 'hello',
+                    area: {
+                      x: 520,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                ],
               },
-              actions: [
-                {
-                  type: 'uri',
-                  linkUri: 'https://example.com/',
-                  area: {
-                    x: 0,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-                {
-                  type: 'message',
-                  text: 'hello',
-                  area: {
-                    x: 520,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-              ],
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushImagemap(
         RECIPIENT_ID,
@@ -447,43 +505,47 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'imagemap',
-              baseUrl: 'https://example.com/bot/images/rm001',
-              altText: 'this is an imagemap',
-              baseSize: {
-                height: 1040,
-                width: 1040,
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'imagemap',
+                baseUrl: 'https://example.com/bot/images/rm001',
+                altText: 'this is an imagemap',
+                baseSize: {
+                  height: 1040,
+                  width: 1040,
+                },
+                actions: [
+                  {
+                    type: 'uri',
+                    linkUri: 'https://example.com/',
+                    area: {
+                      x: 0,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                  {
+                    type: 'message',
+                    text: 'hello',
+                    area: {
+                      x: 520,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                ],
               },
-              actions: [
-                {
-                  type: 'uri',
-                  linkUri: 'https://example.com/',
-                  area: {
-                    x: 0,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-                {
-                  type: 'message',
-                  text: 'hello',
-                  area: {
-                    x: 520,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-              ],
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushImagemap(
         RECIPIENT_ID,
@@ -528,57 +590,61 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'imagemap',
-              baseUrl: 'https://example.com/bot/images/rm001',
-              altText: 'this is an imagemap',
-              baseSize: {
-                height: 1040,
-                width: 1040,
-              },
-              video: {
-                originalContentUrl: 'https://example.com/video.mp4',
-                previewImageUrl: 'https://example.com/video_preview.jpg',
-                area: {
-                  x: 0,
-                  y: 0,
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'imagemap',
+                baseUrl: 'https://example.com/bot/images/rm001',
+                altText: 'this is an imagemap',
+                baseSize: {
+                  height: 1040,
                   width: 1040,
-                  height: 585,
                 },
-                externalLink: {
-                  linkUri: 'https://example.com/see_more.html',
-                  label: 'See More',
-                },
-              },
-              actions: [
-                {
-                  type: 'uri',
-                  linkUri: 'https://example.com/',
+                video: {
+                  originalContentUrl: 'https://example.com/video.mp4',
+                  previewImageUrl: 'https://example.com/video_preview.jpg',
                   area: {
                     x: 0,
                     y: 0,
-                    width: 520,
-                    height: 1040,
+                    width: 1040,
+                    height: 585,
+                  },
+                  externalLink: {
+                    linkUri: 'https://example.com/see_more.html',
+                    label: 'See More',
                   },
                 },
-                {
-                  type: 'message',
-                  text: 'hello',
-                  area: {
-                    x: 520,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
+                actions: [
+                  {
+                    type: 'uri',
+                    linkUri: 'https://example.com/',
+                    area: {
+                      x: 0,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
                   },
-                },
-              ],
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+                  {
+                    type: 'message',
+                    text: 'hello',
+                    area: {
+                      x: 520,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushImagemap(
         RECIPIENT_ID,
@@ -639,39 +705,43 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a template',
-              template: {
-                type: 'buttons',
-                thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
-                title: 'Menu',
-                text: 'Please select',
-                actions: [
-                  {
-                    type: 'postback',
-                    label: 'Buy',
-                    data: 'action=buy&itemid=123',
-                  },
-                  {
-                    type: 'postback',
-                    label: 'Add to cart',
-                    data: 'action=add&itemid=123',
-                  },
-                  {
-                    type: 'uri',
-                    label: 'View detail',
-                    uri: 'http://example.com/page/123',
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a template',
+                template: {
+                  type: 'buttons',
+                  thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+                  title: 'Menu',
+                  text: 'Please select',
+                  actions: [
+                    {
+                      type: 'postback',
+                      label: 'Buy',
+                      data: 'action=buy&itemid=123',
+                    },
+                    {
+                      type: 'postback',
+                      label: 'Add to cart',
+                      data: 'action=add&itemid=123',
+                    },
+                    {
+                      type: 'uri',
+                      label: 'View detail',
+                      uri: 'http://example.com/page/123',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushTemplate(
         RECIPIENT_ID,
@@ -712,47 +782,51 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a template',
-              template: {
-                type: 'buttons',
-                thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
-                imageAspectRatio: 'rectangle',
-                imageSize: 'cover',
-                imageBackgroundColor: '#FFFFFF',
-                title: 'Menu',
-                text: 'Please select',
-                defaultAction: {
-                  type: 'uri',
-                  label: 'View detail',
-                  uri: 'http://example.com/page/123',
-                },
-                actions: [
-                  {
-                    type: 'postback',
-                    label: 'Buy',
-                    data: 'action=buy&itemid=123',
-                  },
-                  {
-                    type: 'postback',
-                    label: 'Add to cart',
-                    data: 'action=add&itemid=123',
-                  },
-                  {
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a template',
+                template: {
+                  type: 'buttons',
+                  thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+                  imageAspectRatio: 'rectangle',
+                  imageSize: 'cover',
+                  imageBackgroundColor: '#FFFFFF',
+                  title: 'Menu',
+                  text: 'Please select',
+                  defaultAction: {
                     type: 'uri',
                     label: 'View detail',
                     uri: 'http://example.com/page/123',
                   },
-                ],
+                  actions: [
+                    {
+                      type: 'postback',
+                      label: 'Buy',
+                      data: 'action=buy&itemid=123',
+                    },
+                    {
+                      type: 'postback',
+                      label: 'Add to cart',
+                      data: 'action=add&itemid=123',
+                    },
+                    {
+                      type: 'uri',
+                      label: 'View detail',
+                      uri: 'http://example.com/page/123',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushButtonTemplate(
         RECIPIENT_ID,
@@ -798,42 +872,46 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a template',
-              template: {
-                type: 'buttons',
-                thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
-                imageAspectRatio: 'rectangle',
-                imageSize: 'cover',
-                imageBackgroundColor: '#FFFFFF',
-                title: 'Menu',
-                text: 'Please select',
-                actions: [
-                  {
-                    type: 'postback',
-                    label: 'Buy',
-                    data: 'action=buy&itemid=123',
-                  },
-                  {
-                    type: 'postback',
-                    label: 'Add to cart',
-                    data: 'action=add&itemid=123',
-                  },
-                  {
-                    type: 'uri',
-                    label: 'View detail',
-                    uri: 'http://example.com/page/123',
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a template',
+                template: {
+                  type: 'buttons',
+                  thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+                  imageAspectRatio: 'rectangle',
+                  imageSize: 'cover',
+                  imageBackgroundColor: '#FFFFFF',
+                  title: 'Menu',
+                  text: 'Please select',
+                  actions: [
+                    {
+                      type: 'postback',
+                      label: 'Buy',
+                      data: 'action=buy&itemid=123',
+                    },
+                    {
+                      type: 'postback',
+                      label: 'Add to cart',
+                      data: 'action=add&itemid=123',
+                    },
+                    {
+                      type: 'uri',
+                      label: 'View detail',
+                      uri: 'http://example.com/page/123',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushButtonsTemplate(
         RECIPIENT_ID,
@@ -876,32 +954,36 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a confirm template',
-              template: {
-                type: 'confirm',
-                text: 'Are you sure?',
-                actions: [
-                  {
-                    type: 'message',
-                    label: 'Yes',
-                    text: 'yes',
-                  },
-                  {
-                    type: 'message',
-                    label: 'No',
-                    text: 'no',
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a confirm template',
+                template: {
+                  type: 'confirm',
+                  text: 'Are you sure?',
+                  actions: [
+                    {
+                      type: 'message',
+                      label: 'Yes',
+                      text: 'yes',
+                    },
+                    {
+                      type: 'message',
+                      label: 'No',
+                      text: 'no',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushConfirmTemplate(
         RECIPIENT_ID,
@@ -934,69 +1016,73 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a carousel template',
-              template: {
-                type: 'carousel',
-                imageAspectRatio: 'rectangle',
-                imageSize: 'cover',
-                columns: [
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item1.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=111',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=111',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/111',
-                      },
-                    ],
-                  },
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item2.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=222',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=222',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/222',
-                      },
-                    ],
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a carousel template',
+                template: {
+                  type: 'carousel',
+                  imageAspectRatio: 'rectangle',
+                  imageSize: 'cover',
+                  columns: [
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item1.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=111',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=111',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/111',
+                        },
+                      ],
+                    },
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item2.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=222',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=222',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/222',
+                        },
+                      ],
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushCarouselTemplate(
         RECIPIENT_ID,
@@ -1062,67 +1148,71 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a carousel template',
-              template: {
-                type: 'carousel',
-                columns: [
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item1.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=111',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=111',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/111',
-                      },
-                    ],
-                  },
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item2.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=222',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=222',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/222',
-                      },
-                    ],
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a carousel template',
+                template: {
+                  type: 'carousel',
+                  columns: [
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item1.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=111',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=111',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/111',
+                        },
+                      ],
+                    },
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item2.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=222',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=222',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/222',
+                        },
+                      ],
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushCarouselTemplate(
         RECIPIENT_ID,
@@ -1186,45 +1276,49 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is an image carousel template',
-              template: {
-                type: 'image_carousel',
-                columns: [
-                  {
-                    imageUrl: 'https://example.com/bot/images/item1.jpg',
-                    action: {
-                      type: 'postback',
-                      label: 'Buy',
-                      data: 'action=buy&itemid=111',
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is an image carousel template',
+                template: {
+                  type: 'image_carousel',
+                  columns: [
+                    {
+                      imageUrl: 'https://example.com/bot/images/item1.jpg',
+                      action: {
+                        type: 'postback',
+                        label: 'Buy',
+                        data: 'action=buy&itemid=111',
+                      },
                     },
-                  },
-                  {
-                    imageUrl: 'https://example.com/bot/images/item2.jpg',
-                    action: {
-                      type: 'message',
-                      label: 'Yes',
-                      text: 'yes',
+                    {
+                      imageUrl: 'https://example.com/bot/images/item2.jpg',
+                      action: {
+                        type: 'message',
+                        label: 'Yes',
+                        text: 'yes',
+                      },
                     },
-                  },
-                  {
-                    imageUrl: 'https://example.com/bot/images/item3.jpg',
-                    action: {
-                      type: 'uri',
-                      label: 'View detail',
-                      uri: 'http://example.com/page/222',
+                    {
+                      imageUrl: 'https://example.com/bot/images/item3.jpg',
+                      action: {
+                        type: 'uri',
+                        label: 'View detail',
+                        uri: 'http://example.com/page/222',
+                      },
                     },
-                  },
-                ],
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushImageCarouselTemplate(
         RECIPIENT_ID,
@@ -1268,56 +1362,60 @@ describe('Push Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/push', {
-          to: RECIPIENT_ID,
-          messages: [
-            {
-              type: 'flex',
-              altText: 'this is a flex message',
-              contents: {
-                type: 'bubble',
-                header: {
-                  type: 'box',
-                  layout: 'vertical',
-                  contents: [
-                    {
-                      type: 'text',
-                      text: 'Header text',
-                    },
-                  ],
-                },
-                hero: {
-                  type: 'image',
-                  url: 'https://example.com/flex/images/image.jpg',
-                },
-                body: {
-                  type: 'box',
-                  layout: 'vertical',
-                  contents: [
-                    {
-                      type: 'text',
-                      text: 'Body text',
-                    },
-                  ],
-                },
-                footer: {
-                  type: 'box',
-                  layout: 'vertical',
-                  contents: [
-                    {
-                      type: 'text',
-                      text: 'Footer text',
-                    },
-                  ],
-                },
-                styles: {
-                  comment: 'See the example of a bubble style object',
+        .onPost(
+          '/v2/bot/message/push',
+          {
+            to: RECIPIENT_ID,
+            messages: [
+              {
+                type: 'flex',
+                altText: 'this is a flex message',
+                contents: {
+                  type: 'bubble',
+                  header: {
+                    type: 'box',
+                    layout: 'vertical',
+                    contents: [
+                      {
+                        type: 'text',
+                        text: 'Header text',
+                      },
+                    ],
+                  },
+                  hero: {
+                    type: 'image',
+                    url: 'https://example.com/flex/images/image.jpg',
+                  },
+                  body: {
+                    type: 'box',
+                    layout: 'vertical',
+                    contents: [
+                      {
+                        type: 'text',
+                        text: 'Body text',
+                      },
+                    ],
+                  },
+                  footer: {
+                    type: 'box',
+                    layout: 'vertical',
+                    contents: [
+                      {
+                        type: 'text',
+                        text: 'Footer text',
+                      },
+                    ],
+                  },
+                  styles: {
+                    comment: 'See the example of a bubble style object',
+                  },
                 },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.pushFlex(
         RECIPIENT_ID,

--- a/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.js
@@ -7,6 +7,8 @@ const ACCESS_TOKEN = '1234567890';
 const CHANNEL_SECRET = 'so-secret';
 
 const headers = {
+  Accept: 'application/json, text/plain, */*',
+  'Content-Type': 'application/json',
   Authorization: `Bearer ${ACCESS_TOKEN}`,
 };
 
@@ -24,11 +26,15 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [{ type: 'text', text: 'Hello!' }],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [{ type: 'text', text: 'Hello!' }],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyRawBody({
         replyToken: REPLY_TOKEN,
@@ -51,11 +57,15 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [{ type: 'text', text: 'Hello!' }],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [{ type: 'text', text: 'Hello!' }],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.reply(REPLY_TOKEN, [
         {
@@ -75,11 +85,15 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [{ type: 'text', text: 'Hello!' }],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [{ type: 'text', text: 'Hello!' }],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyText(REPLY_TOKEN, 'Hello!');
 
@@ -94,17 +108,21 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'image',
-              originalContentUrl: 'https://example.com/original.jpg',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'image',
+                originalContentUrl: 'https://example.com/original.jpg',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyImage(
         REPLY_TOKEN,
@@ -121,17 +139,21 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'image',
-              originalContentUrl: 'https://example.com/original.jpg',
-              previewImageUrl: 'https://example.com/original.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'image',
+                originalContentUrl: 'https://example.com/original.jpg',
+                previewImageUrl: 'https://example.com/original.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyImage(
         REPLY_TOKEN,
@@ -147,17 +169,21 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'image',
-              originalContentUrl: 'https://example.com/original.jpg',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'image',
+                originalContentUrl: 'https://example.com/original.jpg',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyImage(REPLY_TOKEN, {
         originalContentUrl: 'https://example.com/original.jpg',
@@ -175,17 +201,21 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'video',
-              originalContentUrl: 'https://example.com/original.mp4',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'video',
+                originalContentUrl: 'https://example.com/original.mp4',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyVideo(
         REPLY_TOKEN,
@@ -202,17 +232,21 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'video',
-              originalContentUrl: 'https://example.com/original.mp4',
-              previewImageUrl: 'https://example.com/preview.jpg',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'video',
+                originalContentUrl: 'https://example.com/original.mp4',
+                previewImageUrl: 'https://example.com/preview.jpg',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyVideo(REPLY_TOKEN, {
         originalContentUrl: 'https://example.com/original.mp4',
@@ -230,17 +264,21 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'audio',
-              originalContentUrl: 'https://example.com/original.m4a',
-              duration: 240000,
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'audio',
+                originalContentUrl: 'https://example.com/original.m4a',
+                duration: 240000,
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyAudio(
         REPLY_TOKEN,
@@ -257,17 +295,21 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'audio',
-              originalContentUrl: 'https://example.com/original.m4a',
-              duration: 240000,
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'audio',
+                originalContentUrl: 'https://example.com/original.m4a',
+                duration: 240000,
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyAudio(REPLY_TOKEN, {
         originalContentUrl: 'https://example.com/original.m4a',
@@ -285,19 +327,23 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'location',
-              title: 'my location',
-              address: '〒150-0002 東京都渋谷区渋谷２丁目２１−１',
-              latitude: 35.65910807942215,
-              longitude: 139.70372892916203,
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'location',
+                title: 'my location',
+                address: '〒150-0002 東京都渋谷区渋谷２丁目２１−１',
+                latitude: 35.65910807942215,
+                longitude: 139.70372892916203,
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyLocation(REPLY_TOKEN, {
         title: 'my location',
@@ -317,17 +363,21 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'sticker',
-              packageId: '1',
-              stickerId: '1',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'sticker',
+                packageId: '1',
+                stickerId: '1',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replySticker(REPLY_TOKEN, '1', '1');
 
@@ -340,17 +390,21 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'sticker',
-              packageId: '1',
-              stickerId: '1',
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'sticker',
+                packageId: '1',
+                stickerId: '1',
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replySticker(REPLY_TOKEN, {
         packageId: '1',
@@ -368,43 +422,47 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'imagemap',
-              baseUrl: 'https://example.com/bot/images/rm001',
-              altText: 'this is an imagemap',
-              baseSize: {
-                height: 1040,
-                width: 1040,
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'imagemap',
+                baseUrl: 'https://example.com/bot/images/rm001',
+                altText: 'this is an imagemap',
+                baseSize: {
+                  height: 1040,
+                  width: 1040,
+                },
+                actions: [
+                  {
+                    type: 'uri',
+                    linkUri: 'https://example.com/',
+                    area: {
+                      x: 0,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                  {
+                    type: 'message',
+                    text: 'hello',
+                    area: {
+                      x: 520,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                ],
               },
-              actions: [
-                {
-                  type: 'uri',
-                  linkUri: 'https://example.com/',
-                  area: {
-                    x: 0,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-                {
-                  type: 'message',
-                  text: 'hello',
-                  area: {
-                    x: 520,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-              ],
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyImagemap(
         REPLY_TOKEN,
@@ -447,43 +505,47 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'imagemap',
-              baseUrl: 'https://example.com/bot/images/rm001',
-              altText: 'this is an imagemap',
-              baseSize: {
-                height: 1040,
-                width: 1040,
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'imagemap',
+                baseUrl: 'https://example.com/bot/images/rm001',
+                altText: 'this is an imagemap',
+                baseSize: {
+                  height: 1040,
+                  width: 1040,
+                },
+                actions: [
+                  {
+                    type: 'uri',
+                    linkUri: 'https://example.com/',
+                    area: {
+                      x: 0,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                  {
+                    type: 'message',
+                    text: 'hello',
+                    area: {
+                      x: 520,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                ],
               },
-              actions: [
-                {
-                  type: 'uri',
-                  linkUri: 'https://example.com/',
-                  area: {
-                    x: 0,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-                {
-                  type: 'message',
-                  text: 'hello',
-                  area: {
-                    x: 520,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
-                  },
-                },
-              ],
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyImagemap(
         REPLY_TOKEN,
@@ -528,57 +590,61 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'imagemap',
-              baseUrl: 'https://example.com/bot/images/rm001',
-              altText: 'this is an imagemap',
-              baseSize: {
-                height: 1040,
-                width: 1040,
-              },
-              video: {
-                originalContentUrl: 'https://example.com/video.mp4',
-                previewImageUrl: 'https://example.com/video_preview.jpg',
-                area: {
-                  x: 0,
-                  y: 0,
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'imagemap',
+                baseUrl: 'https://example.com/bot/images/rm001',
+                altText: 'this is an imagemap',
+                baseSize: {
+                  height: 1040,
                   width: 1040,
-                  height: 585,
                 },
-                externalLink: {
-                  linkUri: 'https://example.com/see_more.html',
-                  label: 'See More',
-                },
-              },
-              actions: [
-                {
-                  type: 'uri',
-                  linkUri: 'https://example.com/',
+                video: {
+                  originalContentUrl: 'https://example.com/video.mp4',
+                  previewImageUrl: 'https://example.com/video_preview.jpg',
                   area: {
                     x: 0,
                     y: 0,
-                    width: 520,
-                    height: 1040,
+                    width: 1040,
+                    height: 585,
+                  },
+                  externalLink: {
+                    linkUri: 'https://example.com/see_more.html',
+                    label: 'See More',
                   },
                 },
-                {
-                  type: 'message',
-                  text: 'hello',
-                  area: {
-                    x: 520,
-                    y: 0,
-                    width: 520,
-                    height: 1040,
+                actions: [
+                  {
+                    type: 'uri',
+                    linkUri: 'https://example.com/',
+                    area: {
+                      x: 0,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
                   },
-                },
-              ],
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+                  {
+                    type: 'message',
+                    text: 'hello',
+                    area: {
+                      x: 520,
+                      y: 0,
+                      width: 520,
+                      height: 1040,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyImagemap(
         REPLY_TOKEN,
@@ -639,39 +705,43 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a template',
-              template: {
-                type: 'buttons',
-                thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
-                title: 'Menu',
-                text: 'Please select',
-                actions: [
-                  {
-                    type: 'postback',
-                    label: 'Buy',
-                    data: 'action=buy&itemid=123',
-                  },
-                  {
-                    type: 'postback',
-                    label: 'Add to cart',
-                    data: 'action=add&itemid=123',
-                  },
-                  {
-                    type: 'uri',
-                    label: 'View detail',
-                    uri: 'http://example.com/page/123',
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a template',
+                template: {
+                  type: 'buttons',
+                  thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+                  title: 'Menu',
+                  text: 'Please select',
+                  actions: [
+                    {
+                      type: 'postback',
+                      label: 'Buy',
+                      data: 'action=buy&itemid=123',
+                    },
+                    {
+                      type: 'postback',
+                      label: 'Add to cart',
+                      data: 'action=add&itemid=123',
+                    },
+                    {
+                      type: 'uri',
+                      label: 'View detail',
+                      uri: 'http://example.com/page/123',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyTemplate(
         REPLY_TOKEN,
@@ -712,47 +782,51 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a template',
-              template: {
-                type: 'buttons',
-                thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
-                imageAspectRatio: 'rectangle',
-                imageSize: 'cover',
-                imageBackgroundColor: '#FFFFFF',
-                title: 'Menu',
-                text: 'Please select',
-                defaultAction: {
-                  type: 'uri',
-                  label: 'View detail',
-                  uri: 'http://example.com/page/123',
-                },
-                actions: [
-                  {
-                    type: 'postback',
-                    label: 'Buy',
-                    data: 'action=buy&itemid=123',
-                  },
-                  {
-                    type: 'postback',
-                    label: 'Add to cart',
-                    data: 'action=add&itemid=123',
-                  },
-                  {
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a template',
+                template: {
+                  type: 'buttons',
+                  thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+                  imageAspectRatio: 'rectangle',
+                  imageSize: 'cover',
+                  imageBackgroundColor: '#FFFFFF',
+                  title: 'Menu',
+                  text: 'Please select',
+                  defaultAction: {
                     type: 'uri',
                     label: 'View detail',
                     uri: 'http://example.com/page/123',
                   },
-                ],
+                  actions: [
+                    {
+                      type: 'postback',
+                      label: 'Buy',
+                      data: 'action=buy&itemid=123',
+                    },
+                    {
+                      type: 'postback',
+                      label: 'Add to cart',
+                      data: 'action=add&itemid=123',
+                    },
+                    {
+                      type: 'uri',
+                      label: 'View detail',
+                      uri: 'http://example.com/page/123',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyButtonTemplate(
         REPLY_TOKEN,
@@ -798,42 +872,46 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a template',
-              template: {
-                type: 'buttons',
-                thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
-                imageAspectRatio: 'rectangle',
-                imageSize: 'cover',
-                imageBackgroundColor: '#FFFFFF',
-                title: 'Menu',
-                text: 'Please select',
-                actions: [
-                  {
-                    type: 'postback',
-                    label: 'Buy',
-                    data: 'action=buy&itemid=123',
-                  },
-                  {
-                    type: 'postback',
-                    label: 'Add to cart',
-                    data: 'action=add&itemid=123',
-                  },
-                  {
-                    type: 'uri',
-                    label: 'View detail',
-                    uri: 'http://example.com/page/123',
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a template',
+                template: {
+                  type: 'buttons',
+                  thumbnailImageUrl: 'https://example.com/bot/images/image.jpg',
+                  imageAspectRatio: 'rectangle',
+                  imageSize: 'cover',
+                  imageBackgroundColor: '#FFFFFF',
+                  title: 'Menu',
+                  text: 'Please select',
+                  actions: [
+                    {
+                      type: 'postback',
+                      label: 'Buy',
+                      data: 'action=buy&itemid=123',
+                    },
+                    {
+                      type: 'postback',
+                      label: 'Add to cart',
+                      data: 'action=add&itemid=123',
+                    },
+                    {
+                      type: 'uri',
+                      label: 'View detail',
+                      uri: 'http://example.com/page/123',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyButtonsTemplate(
         REPLY_TOKEN,
@@ -876,32 +954,36 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a confirm template',
-              template: {
-                type: 'confirm',
-                text: 'Are you sure?',
-                actions: [
-                  {
-                    type: 'message',
-                    label: 'Yes',
-                    text: 'yes',
-                  },
-                  {
-                    type: 'message',
-                    label: 'No',
-                    text: 'no',
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a confirm template',
+                template: {
+                  type: 'confirm',
+                  text: 'Are you sure?',
+                  actions: [
+                    {
+                      type: 'message',
+                      label: 'Yes',
+                      text: 'yes',
+                    },
+                    {
+                      type: 'message',
+                      label: 'No',
+                      text: 'no',
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyConfirmTemplate(
         REPLY_TOKEN,
@@ -934,69 +1016,73 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a carousel template',
-              template: {
-                type: 'carousel',
-                imageAspectRatio: 'rectangle',
-                imageSize: 'cover',
-                columns: [
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item1.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=111',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=111',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/111',
-                      },
-                    ],
-                  },
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item2.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=222',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=222',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/222',
-                      },
-                    ],
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a carousel template',
+                template: {
+                  type: 'carousel',
+                  imageAspectRatio: 'rectangle',
+                  imageSize: 'cover',
+                  columns: [
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item1.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=111',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=111',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/111',
+                        },
+                      ],
+                    },
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item2.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=222',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=222',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/222',
+                        },
+                      ],
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyCarouselTemplate(
         REPLY_TOKEN,
@@ -1062,67 +1148,71 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is a carousel template',
-              template: {
-                type: 'carousel',
-                columns: [
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item1.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=111',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=111',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/111',
-                      },
-                    ],
-                  },
-                  {
-                    thumbnailImageUrl:
-                      'https://example.com/bot/images/item2.jpg',
-                    title: 'this is menu',
-                    text: 'description',
-                    actions: [
-                      {
-                        type: 'postback',
-                        label: 'Buy',
-                        data: 'action=buy&itemid=222',
-                      },
-                      {
-                        type: 'postback',
-                        label: 'Add to cart',
-                        data: 'action=add&itemid=222',
-                      },
-                      {
-                        type: 'uri',
-                        label: 'View detail',
-                        uri: 'http://example.com/page/222',
-                      },
-                    ],
-                  },
-                ],
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is a carousel template',
+                template: {
+                  type: 'carousel',
+                  columns: [
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item1.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=111',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=111',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/111',
+                        },
+                      ],
+                    },
+                    {
+                      thumbnailImageUrl:
+                        'https://example.com/bot/images/item2.jpg',
+                      title: 'this is menu',
+                      text: 'description',
+                      actions: [
+                        {
+                          type: 'postback',
+                          label: 'Buy',
+                          data: 'action=buy&itemid=222',
+                        },
+                        {
+                          type: 'postback',
+                          label: 'Add to cart',
+                          data: 'action=add&itemid=222',
+                        },
+                        {
+                          type: 'uri',
+                          label: 'View detail',
+                          uri: 'http://example.com/page/222',
+                        },
+                      ],
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyCarouselTemplate(
         REPLY_TOKEN,
@@ -1186,45 +1276,49 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'template',
-              altText: 'this is an image carousel template',
-              template: {
-                type: 'image_carousel',
-                columns: [
-                  {
-                    imageUrl: 'https://example.com/bot/images/item1.jpg',
-                    action: {
-                      type: 'postback',
-                      label: 'Buy',
-                      data: 'action=buy&itemid=111',
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'template',
+                altText: 'this is an image carousel template',
+                template: {
+                  type: 'image_carousel',
+                  columns: [
+                    {
+                      imageUrl: 'https://example.com/bot/images/item1.jpg',
+                      action: {
+                        type: 'postback',
+                        label: 'Buy',
+                        data: 'action=buy&itemid=111',
+                      },
                     },
-                  },
-                  {
-                    imageUrl: 'https://example.com/bot/images/item2.jpg',
-                    action: {
-                      type: 'message',
-                      label: 'Yes',
-                      text: 'yes',
+                    {
+                      imageUrl: 'https://example.com/bot/images/item2.jpg',
+                      action: {
+                        type: 'message',
+                        label: 'Yes',
+                        text: 'yes',
+                      },
                     },
-                  },
-                  {
-                    imageUrl: 'https://example.com/bot/images/item3.jpg',
-                    action: {
-                      type: 'uri',
-                      label: 'View detail',
-                      uri: 'http://example.com/page/222',
+                    {
+                      imageUrl: 'https://example.com/bot/images/item3.jpg',
+                      action: {
+                        type: 'uri',
+                        label: 'View detail',
+                        uri: 'http://example.com/page/222',
+                      },
                     },
-                  },
-                ],
+                  ],
+                },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyImageCarouselTemplate(
         REPLY_TOKEN,
@@ -1268,56 +1362,60 @@ describe('Reply Message', () => {
       const reply = {};
 
       mock
-        .onPost('/v2/bot/message/reply', {
-          replyToken: REPLY_TOKEN,
-          messages: [
-            {
-              type: 'flex',
-              altText: 'this is a flex message',
-              contents: {
-                type: 'bubble',
-                header: {
-                  type: 'box',
-                  layout: 'vertical',
-                  contents: [
-                    {
-                      type: 'text',
-                      text: 'Header text',
-                    },
-                  ],
-                },
-                hero: {
-                  type: 'image',
-                  url: 'https://example.com/flex/images/image.jpg',
-                },
-                body: {
-                  type: 'box',
-                  layout: 'vertical',
-                  contents: [
-                    {
-                      type: 'text',
-                      text: 'Body text',
-                    },
-                  ],
-                },
-                footer: {
-                  type: 'box',
-                  layout: 'vertical',
-                  contents: [
-                    {
-                      type: 'text',
-                      text: 'Footer text',
-                    },
-                  ],
-                },
-                styles: {
-                  comment: 'See the example of a bubble style object',
+        .onPost(
+          '/v2/bot/message/reply',
+          {
+            replyToken: REPLY_TOKEN,
+            messages: [
+              {
+                type: 'flex',
+                altText: 'this is a flex message',
+                contents: {
+                  type: 'bubble',
+                  header: {
+                    type: 'box',
+                    layout: 'vertical',
+                    contents: [
+                      {
+                        type: 'text',
+                        text: 'Header text',
+                      },
+                    ],
+                  },
+                  hero: {
+                    type: 'image',
+                    url: 'https://example.com/flex/images/image.jpg',
+                  },
+                  body: {
+                    type: 'box',
+                    layout: 'vertical',
+                    contents: [
+                      {
+                        type: 'text',
+                        text: 'Body text',
+                      },
+                    ],
+                  },
+                  footer: {
+                    type: 'box',
+                    layout: 'vertical',
+                    contents: [
+                      {
+                        type: 'text',
+                        text: 'Footer text',
+                      },
+                    ],
+                  },
+                  styles: {
+                    comment: 'See the example of a bubble style object',
+                  },
                 },
               },
-            },
-          ],
-        })
-        .reply(200, reply, headers);
+            ],
+          },
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.replyFlex(
         REPLY_TOKEN,

--- a/packages/messaging-api-line/src/__tests__/LineClient-room-group.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-room-group.spec.js
@@ -9,6 +9,8 @@ const ACCESS_TOKEN = '1234567890';
 const CHANNEL_SECRET = 'so-secret';
 
 const headers = {
+  Accept: 'application/json, text/plain, */*',
+  'Content-Type': 'application/json',
   Authorization: `Bearer ${ACCESS_TOKEN}`,
 };
 
@@ -29,8 +31,12 @@ describe('Group/Room Member', () => {
       };
 
       mock
-        .onGet(`/v2/bot/group/${GROUP_ID}/member/${RECIPIENT_ID}`)
-        .reply(200, reply, headers);
+        .onGet(
+          `/v2/bot/group/${GROUP_ID}/member/${RECIPIENT_ID}`,
+          undefined,
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.getGroupMemberProfile(GROUP_ID, RECIPIENT_ID);
 
@@ -48,8 +54,12 @@ describe('Group/Room Member', () => {
       };
 
       mock
-        .onGet(`/v2/bot/room/${ROOM_ID}/member/${RECIPIENT_ID}`)
-        .reply(200, reply, headers);
+        .onGet(
+          `/v2/bot/room/${ROOM_ID}/member/${RECIPIENT_ID}`,
+          undefined,
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.getRoomMemberProfile(ROOM_ID, RECIPIENT_ID);
 
@@ -69,8 +79,8 @@ describe('Group/Room Member', () => {
       };
 
       mock
-        .onGet(`/v2/bot/group/${GROUP_ID}/members/ids`)
-        .reply(200, reply, headers);
+        .onGet(`/v2/bot/group/${GROUP_ID}/members/ids`, undefined, headers)
+        .reply(200, reply);
 
       const res = await client.getGroupMemberIds(GROUP_ID);
 
@@ -91,9 +101,11 @@ describe('Group/Room Member', () => {
 
       mock
         .onGet(
-          `/v2/bot/group/${GROUP_ID}/members/ids?start=${continuationToken}`
+          `/v2/bot/group/${GROUP_ID}/members/ids?start=${continuationToken}`,
+          undefined,
+          headers
         )
-        .reply(200, reply, headers);
+        .reply(200, reply);
 
       const res = await client.getGroupMemberIds(GROUP_ID, continuationToken);
 
@@ -122,12 +134,14 @@ describe('Group/Room Member', () => {
       };
 
       mock
-        .onGet(`/v2/bot/group/${GROUP_ID}/members/ids`)
-        .replyOnce(200, reply1, headers)
+        .onGet(`/v2/bot/group/${GROUP_ID}/members/ids`, undefined, headers)
+        .replyOnce(200, reply1)
         .onGet(
-          `/v2/bot/group/${GROUP_ID}/members/ids?start=${continuationToken}`
+          `/v2/bot/group/${GROUP_ID}/members/ids?start=${continuationToken}`,
+          undefined,
+          headers
         )
-        .replyOnce(200, reply2, headers);
+        .replyOnce(200, reply2);
 
       const res = await client.getAllGroupMemberIds(GROUP_ID);
 
@@ -154,8 +168,8 @@ describe('Group/Room Member', () => {
       };
 
       mock
-        .onGet(`/v2/bot/room/${ROOM_ID}/members/ids`)
-        .reply(200, reply, headers);
+        .onGet(`/v2/bot/room/${ROOM_ID}/members/ids`, undefined, headers)
+        .reply(200, reply);
 
       const res = await client.getRoomMemberIds(ROOM_ID);
 
@@ -175,8 +189,12 @@ describe('Group/Room Member', () => {
       const continuationToken = 'TOKEN';
 
       mock
-        .onGet(`/v2/bot/room/${ROOM_ID}/members/ids?start=${continuationToken}`)
-        .reply(200, reply, headers);
+        .onGet(
+          `/v2/bot/room/${ROOM_ID}/members/ids?start=${continuationToken}`,
+          undefined,
+          headers
+        )
+        .reply(200, reply);
 
       const res = await client.getRoomMemberIds(ROOM_ID, continuationToken);
 
@@ -205,7 +223,7 @@ describe('Group/Room Member', () => {
       };
 
       mock
-        .onGet(`/v2/bot/room/${ROOM_ID}/members/ids`)
+        .onGet(`/v2/bot/room/${ROOM_ID}/members/ids`, undefined, headers)
         .replyOnce(200, reply1, headers)
         .onGet(`/v2/bot/room/${ROOM_ID}/members/ids?start=${continuationToken}`)
         .replyOnce(200, reply2, headers);
@@ -231,7 +249,9 @@ describe('Leave', () => {
 
       const reply = {};
 
-      mock.onPost(`/v2/bot/group/${GROUP_ID}/leave`).reply(200, reply, headers);
+      mock
+        .onPost(`/v2/bot/group/${GROUP_ID}/leave`, undefined, headers)
+        .reply(200, reply);
 
       const res = await client.leaveGroup(GROUP_ID);
 
@@ -245,7 +265,9 @@ describe('Leave', () => {
 
       const reply = {};
 
-      mock.onPost(`/v2/bot/room/${ROOM_ID}/leave`).reply(200, reply, headers);
+      mock
+        .onPost(`/v2/bot/room/${ROOM_ID}/leave`, undefined, headers)
+        .reply(200, reply);
 
       const res = await client.leaveRoom(ROOM_ID);
 

--- a/packages/messaging-api-line/src/__tests__/LineClient.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient.spec.js
@@ -8,6 +8,8 @@ const ACCESS_TOKEN = '1234567890';
 const CHANNEL_SECRET = 'so-secret';
 
 const headers = {
+  Accept: 'application/json, text/plain, */*',
+  'Content-Type': 'application/json',
   Authorization: `Bearer ${ACCESS_TOKEN}`,
 };
 
@@ -26,7 +28,9 @@ describe('Content', () => {
 
       const MESSAGE_ID = '1234567890';
 
-      mock.onGet(`/v2/bot/message/${MESSAGE_ID}/content`).reply(200, reply);
+      mock
+        .onGet(`/v2/bot/message/${MESSAGE_ID}/content`, undefined, headers)
+        .reply(200, reply);
 
       const res = await client.retrieveMessageContent(MESSAGE_ID);
 
@@ -46,7 +50,9 @@ describe('Profile', () => {
         statusMessage: 'Hello, LINE!',
       };
 
-      mock.onGet(`/v2/bot/profile/${RECIPIENT_ID}`).reply(200, reply, headers);
+      mock
+        .onGet(`/v2/bot/profile/${RECIPIENT_ID}`, undefined, headers)
+        .reply(200, reply);
 
       const res = await client.getUserProfile(RECIPIENT_ID);
 
@@ -64,8 +70,8 @@ describe('Account link', () => {
       };
 
       mock
-        .onPost(`/v2/bot/user/${RECIPIENT_ID}/linkToken`)
-        .reply(200, reply, headers);
+        .onPost(`/v2/bot/user/${RECIPIENT_ID}/linkToken`, undefined, headers)
+        .reply(200, reply);
 
       const res = await client.issueLinkToken(RECIPIENT_ID);
 


### PR DESCRIPTION
according to the offical doc(or test cases)

here's the params that mock function accepts:
```js
mock.onGet('/', { params: { searchText: 'John' }, {  'Header-test': 'test-header' } )

mock.onPost('/', {params: { searchText: 'John'}, {  'Header-test': 'test-header' } )
```

I think the rest of them are the same so the tests should be modified as this pr.