### PR TITLE
refine rich menu getter functions error handling when getting 404

### DIFF
--- a/packages/messaging-api-line/src/LineClient.js
+++ b/packages/messaging-api-line/src/LineClient.js
@@ -783,7 +783,13 @@ export default class LineClient {
           headers: { Authorization: `Bearer ${customAccessToken}` },
         }
       )
-      .then(res => res.data, handleError);
+      .then(res => res.data)
+      .catch(err => {
+        if (err.response && err.response.status === 404) {
+          return null;
+        }
+        handleError(err);
+      });
   }
 
   createRichMenu(
@@ -826,7 +832,13 @@ export default class LineClient {
           headers: { Authorization: `Bearer ${customAccessToken}` },
         }
       )
-      .then(res => res.data, handleError);
+      .then(res => res.data)
+      .catch(err => {
+        if (err.response && err.response.status === 404) {
+          return null;
+        }
+        handleError(err);
+      });
   }
 
   linkRichMenu(
@@ -869,7 +881,13 @@ export default class LineClient {
           headers: { Authorization: `Bearer ${customAccessToken}` },
         }
       )
-      .then(res => res.data, handleError);
+      .then(res => res.data)
+      .catch(err => {
+        if (err.response && err.response.status === 404) {
+          return null;
+        }
+        handleError(err);
+      });
   }
 
   setDefaultRichMenu(
@@ -947,7 +965,13 @@ export default class LineClient {
               responseType: 'arraybuffer',
             }
       )
-      .then(res => Buffer.from(res.data), handleError);
+      .then(res => Buffer.from(res.data))
+      .catch(err => {
+        if (err.response && err.response.status === 404) {
+          return null;
+        }
+        handleError(err);
+      });
   }
 
   /**

--- a/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.js
@@ -268,6 +268,21 @@ describe('Rich Menu', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('should return null when no rich menu found', async () => {
+      const { client, mock } = createMock();
+
+      mock.onGet().reply(404, {
+        message: 'richmenu not found',
+        details: [],
+      });
+
+      const res = await client.getRichMenu(
+        'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'
+      );
+
+      expect(res).toEqual(null);
+    });
   });
 
   describe('#createRichMenu', () => {
@@ -467,6 +482,21 @@ describe('Rich Menu', () => {
       });
 
       expect(res).toEqual(reply);
+    });
+
+    it('should return null when no rich menu found', async () => {
+      const { client, mock } = createMock();
+
+      mock.onGet().reply(404, {
+        message: 'the user has no richmenu',
+        details: [],
+      });
+
+      const res = await client.getLinkedRichMenu(
+        'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'
+      );
+
+      expect(res).toEqual(null);
     });
   });
 
@@ -711,6 +741,18 @@ describe('Rich Menu', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('should return null when no rich menu image found', async () => {
+      const { client, mock } = createMock();
+
+      mock.onGet().reply(404, Buffer.from('{"message":"Not found"}'));
+
+      const res = await client.downloadRichMenuImage(
+        'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'
+      );
+
+      expect(res).toEqual(null);
+    });
   });
 
   describe('#getDefaultRichMenu', () => {
@@ -762,6 +804,21 @@ describe('Rich Menu', () => {
       });
 
       expect(res).toEqual(reply);
+    });
+
+    it('should return null when no default rich menu found', async () => {
+      const { client, mock } = createMock();
+
+      mock.onGet().reply(404, {
+        message: 'no default richmenu',
+        details: [],
+      });
+
+      const res = await client.getDefaultRichMenu(
+        'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'
+      );
+
+      expect(res).toEqual(null);
     });
   });
 


### PR DESCRIPTION
i think it's better to return null than throw an error and blow the whole flow up (or you have to try catch almost every getter function).