### PR TITLE
add getThreadOwner in MessengerBatch

### DIFF
--- a/packages/messaging-api-messenger/src/MessengerBatch.js
+++ b/packages/messaging-api-messenger/src/MessengerBatch.js
@@ -368,6 +368,20 @@ function requestThreadControl(
   };
 }
 
+function getThreadOwner(
+  recipientId: string,
+  options?: { access_token: ?string }
+) {
+  return {
+    method: 'GET',
+    relative_url: 'me/thread_owner',
+    body: {
+      recipient: { id: recipientId },
+      ...omitUndefinedFields(options),
+    },
+  };
+}
+
 function associateLabel(
   userId: UserID,
   labelId: number,
@@ -501,6 +515,7 @@ const MessengerBatch = {
   passThreadControlToPageInbox,
   takeThreadControl,
   requestThreadControl,
+  getThreadOwner,
 
   associateLabel,
   dissociateLabel,

--- a/packages/messaging-api-messenger/src/__tests__/MessengerBatch.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerBatch.spec.js
@@ -1168,6 +1168,18 @@ describe('requestThreadControl', () => {
   });
 });
 
+describe('getThreadOwner', () => {
+  it('should create get thread owner request', () => {
+    expect(MessengerBatch.getThreadOwner(RECIPIENT_ID)).toEqual({
+      method: 'GET',
+      relative_url: 'me/thread_owner',
+      body: {
+        recipient: { id: RECIPIENT_ID },
+      },
+    });
+  });
+});
+
 describe('associateLabel', () => {
   it('should create associate label request', () => {
     expect(MessengerBatch.associateLabel(RECIPIENT_ID, LABEL_ID)).toEqual({


### PR DESCRIPTION
tried to getThreadOwner in Batch request, but it was not implemented