### PR TITLE
feat: add responseAccessPath for batch requests for sending getter re…

### DIFF
--- a/packages/messaging-api-messenger/src/MessengerBatch.js
+++ b/packages/messaging-api-messenger/src/MessengerBatch.js
@@ -377,6 +377,7 @@ function getThreadOwner(
     relative_url: `me/thread_owner?recipient=${recipientId}`.concat(
       options.access_token ? `&access_token=${options.access_token}` : ''
     ),
+    responseAccessPath: 'data[0].thread_owner',
   };
 }
 

--- a/packages/messaging-api-messenger/src/MessengerTypes.js
+++ b/packages/messaging-api-messenger/src/MessengerTypes.js
@@ -332,6 +332,7 @@ export type BatchItem = {
   relative_url: string,
   name?: string,
   body?: Object,
+  responseAccessPath?: string,
 };
 
 export type Model =

--- a/packages/messaging-api-messenger/src/__tests__/MessengerBatch.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerBatch.spec.js
@@ -1173,6 +1173,7 @@ describe('getThreadOwner', () => {
     expect(MessengerBatch.getThreadOwner(RECIPIENT_ID)).toEqual({
       method: 'GET',
       relative_url: 'me/thread_owner?recipient=1QAZ2WSX',
+      responseAccessPath: 'data[0].thread_owner',
     });
   });
 });

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.js
@@ -878,6 +878,42 @@ describe('send api', () => {
       expect(res).toEqual(reply);
     });
 
+    it('should get correct data according to responseAccessPath', async () => {
+      const { client, mock } = createMock();
+
+      const reply = [
+        {
+          body: {
+            data: [
+              {
+                thread_owner: {
+                  app_id: '501514720355337',
+                },
+              },
+            ],
+          },
+        },
+      ];
+
+      const batch = [MessengerBatch.getThreadOwner(USER_ID)];
+
+      mock
+        .onPost('/', {
+          access_token: ACCESS_TOKEN,
+          batch: [
+            {
+              method: 'GET',
+              relative_url: `me/thread_owner?recipient=${USER_ID}`,
+            },
+          ],
+        })
+        .reply(200, reply);
+
+      const res = await client.sendBatch(batch);
+
+      expect(res).toEqual([{ body: { app_id: '501514720355337' } }]);
+    });
+
     it('should throw if item length > 50', async () => {
       const { client } = createMock();
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -46,7 +46,10 @@ const fixedWidth = str => {
   if (lastString.length < WIDTH) {
     lastString += Array(WIDTH - lastString.length).join(chalk.dim('.'));
   }
-  return strs.slice(0, -1).concat(lastString).join('\n');
+  return strs
+    .slice(0, -1)
+    .concat(lastString)
+    .join('\n');
 };
 
 function getPackageName(file) {
@@ -68,14 +71,23 @@ function buildFile(file, silent) {
   if (micromatch.isMatch(file, IGNORE_PATTERN)) {
     if (!silent) {
       process.stdout.write(
-        `${chalk.dim('  \u2022 ')}${path.relative(PACKAGES_DIR, file)} (ignore)\n`
+        `${chalk.dim('  \u2022 ')}${path.relative(
+          PACKAGES_DIR,
+          file
+        )} (ignore)\n`
       );
     }
   } else if (!micromatch.isMatch(file, JS_FILES_PATTERN)) {
     fs.createReadStream(file).pipe(fs.createWriteStream(destPath));
     if (!silent) {
       process.stdout.write(
-        `${chalk.red('  \u2022 ')}${path.relative(PACKAGES_DIR, file)}${chalk.red(' \u21D2 ')}${path.relative(PACKAGES_DIR, destPath)} (copy)\n`
+        `${chalk.red('  \u2022 ')}${path.relative(
+          PACKAGES_DIR,
+          file
+        )}${chalk.red(' \u21D2 ')}${path.relative(
+          PACKAGES_DIR,
+          destPath
+        )} (copy)\n`
       );
     }
   } else {
@@ -83,7 +95,10 @@ function buildFile(file, silent) {
     fs.writeFileSync(destPath, transformed);
     if (!silent) {
       process.stdout.write(
-        `${chalk.green('  \u2022 ')}${path.relative(PACKAGES_DIR, file)}${chalk.green(' \u21D2 ')}${path.relative(PACKAGES_DIR, destPath)}\n`
+        `${chalk.green('  \u2022 ')}${path.relative(
+          PACKAGES_DIR,
+          file
+        )}${chalk.green(' \u21D2 ')}${path.relative(PACKAGES_DIR, destPath)}\n`
       );
     }
   }


### PR DESCRIPTION
…quests

To keep the equality of batched get requests and normal get request, given responseAccessPath, will get from the response body with lodash get.