### PR TITLE
feat(line): return null when no user found

### DIFF
--- a/packages/messaging-api-line/src/LineClient.js
+++ b/packages/messaging-api-line/src/LineClient.js
@@ -589,7 +589,13 @@ export default class LineClient {
           headers: { Authorization: `Bearer ${customAccessToken}` },
         }
       )
-      .then(res => res.data, handleError);
+      .then(res => res.data, handleError)
+      .catch(err => {
+        if (err.response && err.response.status === 404) {
+          return null;
+        }
+        handleError(err);
+      });
   }
 
   /**

--- a/packages/messaging-api-line/src/__tests__/LineClient.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient.spec.js
@@ -92,6 +92,18 @@ describe('Profile', () => {
 
       expect(res).toEqual(reply);
     });
+
+    it('should return null when no user found', async () => {
+      const { client, mock } = createMock();
+
+      mock.onGet().reply(404, {
+        message: 'Not found',
+      });
+
+      const res = await client.getUserProfile(RECIPIENT_ID);
+
+      expect(res).toEqual(null);
+    });
   });
 });
 


### PR DESCRIPTION
Sometimes we can not get some user's profile by id, due to some privacy or unknown platform issue.
So returning null should prevent breaking the handling flow.