### PR TITLE
[Messenger] fix(quick replies): support up to 13 quick replies instead of 11

### DIFF
--- a/packages/messaging-api-messenger/src/Messenger.js
+++ b/packages/messaging-api-messenger/src/Messenger.js
@@ -24,10 +24,10 @@ import type {
 } from './MessengerTypes';
 
 function validateQuickReplies(quickReplies: Array<QuickReply>): void {
-  // quick_replies is limited to 11
+  // quick_replies is limited to 13
   invariant(
-    Array.isArray(quickReplies) && quickReplies.length <= 11,
-    'quick_replies is an array and limited to 11'
+    Array.isArray(quickReplies) && quickReplies.length <= 13,
+    'quick_replies is an array and limited to 13'
   );
 
   quickReplies.forEach(quickReply => {

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.js
@@ -348,10 +348,10 @@ describe('send api', () => {
       expect(res).toEqual(reply);
     });
 
-    it('should throw if quick_replies length > 11', async () => {
+    it('should throw if quick_replies length > 13', async () => {
       const { client } = createMock();
 
-      const lotsOfQuickReplies = new Array(12).fill({
+      const lotsOfQuickReplies = new Array(14).fill({
         content_type: 'text',
         title: 'Red',
         payload: 'DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_RED',
@@ -363,7 +363,7 @@ describe('send api', () => {
           { text: 'Pick a color:' },
           { quick_replies: lotsOfQuickReplies }
         );
-      }).toThrow('quick_replies is an array and limited to 11');
+      }).toThrow('quick_replies is an array and limited to 13');
     });
 
     it('should throw if title length > 20', async () => {


### PR DESCRIPTION
Messenger now accepts 13 quick replies.

https://developers.facebook.com/docs/messenger-platform/send-messages/quick-replies/