### PR TITLE
feat(messenger): update default version to 3.3 and remove deprecated insight methods

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -75,11 +75,11 @@ const client = MessengerClient.connect({
   accessToken: ACCESS_TOKEN,
   appId: APP_ID,
   appSecret: APP_SECRET,
-  version: '2.12',
+  version: '3.3',
 });
 ```
 
-If it is not specified, version `3.0` will be used as default.
+If it is not specified, version `3.3` will be used as default.
 
 ### Verifying Graph API Calls with appsecret_proof
 
@@ -2820,66 +2820,27 @@ Retrieves the insights of your Facebook Page.
 Example:
 
 ```js
-client.getInsights(['page_messages_active_threads_unique']).then(counts => {
-  console.log(counts);
-  // [
-  //   {
-  //     "name": "<METRIC>",
-  //     "period": "day",
-  //     "values": [
-  //       {
-  //         "value": "<VALUE>",
-  //         "end_time": "<UTC_TIMESTAMP>"
-  //       },
-  //       {
-  //         "value": "<VALUE>",
-  //         "end_time": "<UTC_TIMESTAMP>"
-  //       }
-  //     ]
-  //   }
-  // ]
-});
-```
-
-<br />
-
-## `getActiveThreads(options)`
-
-Retrieves a count of the unique active threads your app participated in per day.
-
-| Param         | Type     | Description                                                       |
-| ------------- | -------- | ----------------------------------------------------------------- |
-| options       | `Object` | Optional arguments.                                               |
-| options.since | `number` | Optional. UNIX timestamp of the start time to get the metric for. |
-| options.until | `number` | Optional. UNIX timestamp of the end time to get the metric for.   |
-
-Example:
-
-```js
-client.getActiveThreads().then(counts => {
-  console.log(counts);
-  //   {
-  //     "name": "page_messages_active_threads_unique",
-  //     "period": "day",
-  //     "values": [
-  //       {
-  //         "value": 83111,
-  //         "end_time": "2017-02-02T08:00:00+0000"
-  //       },
-  //       {
-  //         "value": 85215,
-  //         "end_time": "2017-02-03T08:00:00+0000"
-  //       },
-  //       {
-  //         "value": 87175,
-  //         "end_time": "2017-02-04T08:00:00+0000"
-  //       }
-  //    ],
-  //    "title": "Daily unique active threads count by thread fbid",
-  //    "description": "Daily: total unique active threads created between users and page.",
-  //    "id": "1234567/insights/page_messages_active_threads_unique/day"
-  //   }
-});
+client
+  .getInsights(['page_messages_reported_conversations_unique'])
+  .then(counts => {
+    console.log(counts);
+    // [
+    //   {
+    //     "name": "page_messages_reported_conversations_unique",
+    //     "period": "day",
+    //     "values": [
+    //       {
+    //         "value": "<VALUE>",
+    //         "end_time": "<UTC_TIMESTAMP>"
+    //       },
+    //       {
+    //         "value": "<VALUE>",
+    //         "end_time": "<UTC_TIMESTAMP>"
+    //       }
+    //     ]
+    //   }
+    // ]
+  });
 ```
 
 <br />
@@ -2947,48 +2908,6 @@ client.getReportedConversations().then(counts => {
   //       }
   //     ]
   //   }
-});
-```
-
-<br />
-
-## `getReportedConversationsByReportType(options)`
-
-Retrieves the number of conversations from your Page that have been reported by people for reasons such as spam, or containing inappropriate content.
-
-| Param         | Type     | Description                                                       |
-| ------------- | -------- | ----------------------------------------------------------------- |
-| options       | `Object` | Optional arguments.                                               |
-| options.since | `number` | Optional. UNIX timestamp of the start time to get the metric for. |
-| options.until | `number` | Optional. UNIX timestamp of the end time to get the metric for.   |
-
-Example:
-
-```js
-client.getReportedConversationsByReportType().then(counts => {
-  console.log(counts);
-  //   {
-  //     name: 'page_messages_reported_conversations_by_report_type_unique',
-  //     period: 'day',
-  //     values: [
-  //       {
-  //         value: {
-  //           spam: 0,
-  //           inappropriate: 0,
-  //           other: 0,
-  //         },
-  //         end_time: '2018-03-11T08:00:00+0000',
-  //       },
-  //       {
-  //         value: {
-  //           spam: 0,
-  //           inappropriate: 0,
-  //           other: 0,
-  //         },
-  //         end_time: '2018-03-12T07:00:00+0000',
-  //       },
-  //     ],
-  //   },
 });
 ```
 

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -104,7 +104,7 @@ function onRequest(request) {
 export default class MessengerClient {
   static connect(
     accessTokenOrConfig: string | ClientConfig,
-    version?: string = '3.0'
+    version?: string = '3.3'
   ): MessengerClient {
     return new MessengerClient(accessTokenOrConfig, version);
   }
@@ -123,7 +123,7 @@ export default class MessengerClient {
 
   constructor(
     accessTokenOrConfig: string | ClientConfig,
-    version?: string = '3.0'
+    version?: string = '3.3'
   ) {
     let origin;
     let skipAppSecretProof;
@@ -137,7 +137,7 @@ export default class MessengerClient {
       );
       this._appId = config.appId;
       this._appSecret = config.appSecret;
-      this._version = extractVersion(config.version || '3.0');
+      this._version = extractVersion(config.version || '3.3');
       this._onRequest = config.onRequest || onRequest;
       origin = config.origin;
 
@@ -1780,13 +1780,6 @@ export default class MessengerClient {
       .then(res => res.data.data, handleError);
   }
 
-  getActiveThreads(options?: Object = {}) {
-    return this.getInsights(
-      ['page_messages_active_threads_unique'],
-      options
-    ).then(result => result[0]);
-  }
-
   getBlockedConversations(options?: Object = {}) {
     return this.getInsights(
       ['page_messages_blocked_conversations_unique'],
@@ -1797,13 +1790,6 @@ export default class MessengerClient {
   getReportedConversations(options?: Object = {}) {
     return this.getInsights(
       ['page_messages_reported_conversations_unique'],
-      options
-    ).then(result => result[0]);
-  }
-
-  getReportedConversationsByReportType(options?: Object = {}) {
-    return this.getInsights(
-      ['page_messages_reported_conversations_by_report_type_unique'],
       options
     ).then(result => result[0]);
   }

--- a/packages/messaging-api-messenger/src/MessengerTypes.js
+++ b/packages/messaging-api-messenger/src/MessengerTypes.js
@@ -65,10 +65,8 @@ export type MessageTag =
   | 'TICKET_UPDATE';
 
 export type InsightMetric =
-  | 'page_messages_active_threads_unique'
   | 'page_messages_blocked_conversations_unique'
   | 'page_messages_reported_conversations_unique'
-  | 'page_messages_reported_conversations_by_report_type_unique'
   | 'page_messages_total_messaging_connections'
   | 'page_messages_new_conversations_unique';
 

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
@@ -29,7 +29,7 @@ describe('connect', () => {
       MessengerClient.connect(ACCESS_TOKEN);
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v3.0/',
+        baseURL: 'https://graph.facebook.com/v3.3/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -45,7 +45,7 @@ describe('connect', () => {
       MessengerClient.connect({ accessToken: ACCESS_TOKEN });
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v3.0/',
+        baseURL: 'https://graph.facebook.com/v3.3/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -102,7 +102,7 @@ describe('connect', () => {
     });
 
     expect(axios.create).toBeCalledWith({
-      baseURL: 'https://mydummytestserver.com/v3.0/',
+      baseURL: 'https://mydummytestserver.com/v3.3/',
       headers: { 'Content-Type': 'application/json' },
     });
   });
@@ -121,7 +121,7 @@ describe('constructor', () => {
       new MessengerClient(ACCESS_TOKEN); // eslint-disable-line no-new
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v3.0/',
+        baseURL: 'https://graph.facebook.com/v3.3/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -137,7 +137,7 @@ describe('constructor', () => {
       new MessengerClient({ accessToken: ACCESS_TOKEN }); // eslint-disable-line no-new
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v3.0/',
+        baseURL: 'https://graph.facebook.com/v3.3/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -192,7 +192,7 @@ describe('constructor', () => {
     });
 
     expect(axios.create).toBeCalledWith({
-      baseURL: 'https://mydummytestserver.com/v3.0/',
+      baseURL: 'https://mydummytestserver.com/v3.3/',
       headers: { 'Content-Type': 'application/json' },
     });
   });
@@ -200,7 +200,7 @@ describe('constructor', () => {
 
 describe('#version', () => {
   it('should return version of graph api', () => {
-    expect(new MessengerClient(ACCESS_TOKEN).version).toEqual('3.0');
+    expect(new MessengerClient(ACCESS_TOKEN).version).toEqual('3.3');
     expect(new MessengerClient(ACCESS_TOKEN, 'v2.6').version).toEqual('2.6');
     expect(new MessengerClient(ACCESS_TOKEN, '2.6').version).toEqual('2.6');
     expect(() => {
@@ -209,7 +209,7 @@ describe('#version', () => {
     }).toThrow('Type of `version` must be string.');
 
     expect(new MessengerClient({ accessToken: ACCESS_TOKEN }).version).toEqual(
-      '3.0'
+      '3.3'
     );
     expect(
       new MessengerClient({ accessToken: ACCESS_TOKEN, version: 'v2.6' })
@@ -277,7 +277,7 @@ describe('#onRequest', () => {
 
     expect(onRequest).toBeCalledWith({
       method: 'post',
-      url: 'https://graph.facebook.com/v3.0/path',
+      url: 'https://graph.facebook.com/v3.3/path',
       body: {
         x: 1,
       },

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-insights.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-insights.spec.js
@@ -29,24 +29,24 @@ describe('Page Messaging Insights API', () => {
       const reply = {
         data: [
           {
-            name: 'page_messages_active_threads_unique',
+            name: 'page_messages_reported_conversations_unique',
           },
         ],
       };
 
       mock
         .onGet(
-          `/me/insights/?metric=page_messages_active_threads_unique&access_token=${ACCESS_TOKEN}`
+          `/me/insights/?metric=page_messages_reported_conversations_unique&access_token=${ACCESS_TOKEN}`
         )
         .reply(200, reply);
 
       const res = await client.getInsights([
-        'page_messages_active_threads_unique',
+        'page_messages_reported_conversations_unique',
       ]);
 
       expect(res).toEqual([
         {
-          name: 'page_messages_active_threads_unique',
+          name: 'page_messages_reported_conversations_unique',
         },
       ]);
     });
@@ -57,7 +57,7 @@ describe('Page Messaging Insights API', () => {
       const reply = {
         data: [
           {
-            name: 'page_messages_active_threads_unique',
+            name: 'page_messages_reported_conversations_unique',
           },
           {
             name: 'page_messages_blocked_conversations_unique',
@@ -67,88 +67,23 @@ describe('Page Messaging Insights API', () => {
 
       mock
         .onGet(
-          `/me/insights/?metric=page_messages_active_threads_unique%2Cpage_messages_blocked_conversations_unique&access_token=${ACCESS_TOKEN}`
+          `/me/insights/?metric=page_messages_reported_conversations_unique%2Cpage_messages_blocked_conversations_unique&access_token=${ACCESS_TOKEN}`
         )
         .reply(200, reply);
 
       const res = await client.getInsights([
-        'page_messages_active_threads_unique',
+        'page_messages_reported_conversations_unique',
         'page_messages_blocked_conversations_unique',
       ]);
 
       expect(res).toEqual([
         {
-          name: 'page_messages_active_threads_unique',
+          name: 'page_messages_reported_conversations_unique',
         },
         {
           name: 'page_messages_blocked_conversations_unique',
         },
       ]);
-    });
-  });
-
-  describe('#getActiveThreads', () => {
-    it('should call api get Insight data', async () => {
-      const { client, mock } = createMock();
-
-      const reply = {
-        data: [
-          {
-            name: 'page_messages_active_threads_unique',
-            period: 'day',
-            values: [
-              {
-                value: 83111,
-                end_time: '2017-02-02T08:00:00+0000',
-              },
-              {
-                value: 85215,
-                end_time: '2017-02-03T08:00:00+0000',
-              },
-              {
-                value: 87175,
-                end_time: '2017-02-04T08:00:00+0000',
-              },
-            ],
-            title: 'Daily unique active threads count by thread fbid',
-            description:
-              'Daily: total unique active threads created between users and page.',
-            id:
-              '1234567/insights/?metric=page_messages_active_threads_unique/day',
-          },
-        ],
-      };
-
-      mock
-        .onGet(
-          `/me/insights/?metric=page_messages_active_threads_unique&access_token=${ACCESS_TOKEN}`
-        )
-        .reply(200, reply);
-
-      const res = await client.getActiveThreads();
-
-      expect(res).toEqual({
-        name: 'page_messages_active_threads_unique',
-        period: 'day',
-        values: [
-          {
-            value: 83111,
-            end_time: '2017-02-02T08:00:00+0000',
-          },
-          {
-            value: 85215,
-            end_time: '2017-02-03T08:00:00+0000',
-          },
-          {
-            value: 87175,
-            end_time: '2017-02-04T08:00:00+0000',
-          },
-        ],
-        title: 'Daily unique active threads count by thread fbid',
-        description:
-          'Daily: total unique active threads created between users and page.',
-        id: '1234567/insights/?metric=page_messages_active_threads_unique/day',
-      });
     });
   });
 
@@ -280,82 +215,6 @@ describe('Page Messaging Insights API', () => {
           'Daily: The number of conversations from your Page that have been reported by people for reasons such as spam, or containing inappropriate content.',
         id:
           '1234567/insights/?metric=page_messages_reported_conversations_unique/day',
-      });
-    });
-  });
-
-  describe('#getReportedConversationsByReportType', () => {
-    it('should call api get Insight data', async () => {
-      const { client, mock } = createMock();
-
-      const reply = {
-        data: [
-          {
-            name: 'page_messages_reported_conversations_by_report_type_unique',
-            period: 'day',
-            values: [
-              {
-                value: {
-                  spam: 0,
-                  inappropriate: 0,
-                  other: 0,
-                },
-                end_time: '2018-03-11T08:00:00+0000',
-              },
-              {
-                value: {
-                  spam: 0,
-                  inappropriate: 0,
-                  other: 0,
-                },
-                end_time: '2018-03-12T07:00:00+0000',
-              },
-            ],
-            title:
-              'Daily unique reported conversations count broken down by report type',
-            description:
-              'Daily: The number of conversations from your Page that have been reported by people for reasons such as spam, or containing inappropriate content broken down by report type.',
-            id:
-              '1234567/insights/?metric=page_messages_reported_conversations_by_report_type_unique/day',
-          },
-        ],
-      };
-
-      mock
-        .onGet(
-          `/me/insights/?metric=page_messages_reported_conversations_by_report_type_unique&access_token=${ACCESS_TOKEN}`
-        )
-        .reply(200, reply);
-
-      const res = await client.getReportedConversationsByReportType();
-
-      expect(res).toEqual({
-        name: 'page_messages_reported_conversations_by_report_type_unique',
-        period: 'day',
-        values: [
-          {
-            value: {
-              spam: 0,
-              inappropriate: 0,
-              other: 0,
-            },
-            end_time: '2018-03-11T08:00:00+0000',
-          },
-          {
-            value: {
-              spam: 0,
-              inappropriate: 0,
-              other: 0,
-            },
-            end_time: '2018-03-12T07:00:00+0000',
-          },
-        ],
-        title:
-          'Daily unique reported conversations count broken down by report type',
-        description:
-          'Daily: The number of conversations from your Page that have been reported by people for reasons such as spam, or containing inappropriate content broken down by report type.',
-        id:
-          '1234567/insights/?metric=page_messages_reported_conversations_by_report_type_unique/day',
       });
     });
   });

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-persona.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-persona.spec.js
@@ -95,7 +95,7 @@ describe('persona api', () => {
             after: cursor,
           },
           next:
-            'https://graph.facebook.com/v3.0/138523840252451/personas?access_token=0987654321&limit=25&after=QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
+            'https://graph.facebook.com/v3.3/138523840252451/personas?access_token=0987654321&limit=25&after=QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
         },
       };
 
@@ -194,7 +194,7 @@ describe('persona api', () => {
               'QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
           },
           next:
-            'https://graph.facebook.com/v3.0/138523840252451/personas?access_token=0987654321&limit=25&after=QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
+            'https://graph.facebook.com/v3.3/138523840252451/personas?access_token=0987654321&limit=25&after=QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
         },
       };
 

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
@@ -71,7 +71,7 @@ describe('token', () => {
 
       mock.onGet().reply(config => {
         expect(config.baseURL + config.url).toEqual(
-          'https://graph.facebook.com/v3.0/debug_token'
+          'https://graph.facebook.com/v3.3/debug_token'
         );
         expect(config.params).toEqual({
           input_token: ACCESS_TOKEN,


### PR DESCRIPTION
https://developers.facebook.com/docs/graph-api/changelog/version3.3/#messenger

> GET {page_id}/insights — The Messaging Insights API page_messages_active_threads_unique and page_messages_reported_conversations_by_report_type_unique metrics are deprecated.
