### PR TITLE
deprecated: createListTemplate and createOpenGraphTemplate

### DIFF
--- a/packages/messaging-api-messenger/src/Messenger.js
+++ b/packages/messaging-api-messenger/src/Messenger.js
@@ -377,18 +377,17 @@ const Messenger = {
   createTemplate,
   createButtonTemplate,
   createGenericTemplate,
-  createListTemplate,
-  createOpenGraphTemplate,
+  createListTemplate: deprecated('createListTemplate', createListTemplate),
+  createOpenGraphTemplate: deprecated(
+    'createOpenGraphTemplate',
+    createOpenGraphTemplate
+  ),
   createMediaTemplate,
   createReceiptTemplate,
   createAirlineBoardingPassTemplate,
   createAirlineCheckinTemplate,
   createAirlineItineraryTemplate,
   createAirlineUpdateTemplate,
-  createAirlineFlightUpdateTemplate: deprecated(
-    'createAirlineFlightUpdateTemplate',
-    createAirlineUpdateTemplate
-  ),
 };
 
 export default Messenger;

--- a/packages/messaging-api-messenger/src/MessengerBatch.js
+++ b/packages/messaging-api-messenger/src/MessengerBatch.js
@@ -1,5 +1,7 @@
 /* @flow */
 /* eslint-disable camelcase */
+import warning from 'warning';
+
 import Messenger from './Messenger';
 import type {
   AirlineBoardingPassAttributes,
@@ -421,6 +423,18 @@ function getAssociatedLabels(
   };
 }
 
+function deprecated(name, fn) {
+  return (...args: any) => {
+    warning(
+      false,
+      `\`MessengerBatch.${name}\` is deprecated. Use \`MessengerBatch.${
+        fn.name
+      }\` instead.`
+    );
+    return fn(...args);
+  };
+}
+
 const MessengerBatch = {
   sendRequest,
   sendMessage,
@@ -433,8 +447,11 @@ const MessengerBatch = {
   sendTemplate,
   sendButtonTemplate,
   sendGenericTemplate,
-  sendListTemplate,
-  sendOpenGraphTemplate,
+  sendListTemplate: deprecated('sendListTemplate', sendListTemplate),
+  sendOpenGraphTemplate: deprecated(
+    'sendOpenGraphTemplate',
+    sendOpenGraphTemplate
+  ),
   sendReceiptTemplate,
   sendMediaTemplate,
   sendAirlineBoardingPassTemplate,


### PR DESCRIPTION
Adding deprecated warning for those two templates:

https://developers.facebook.com/docs/messenger-platform/send-messages/templates

<img width="669" alt="螢幕快照 2019-07-21 下午4 40 35" src="https://user-images.githubusercontent.com/3382565/61588969-72ddcb80-abd6-11e9-863e-a947688af79e.png">
