### PR TITLE
[Messenger]: graph api v4 and deprecations

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -75,11 +75,11 @@ const client = MessengerClient.connect({
   accessToken: ACCESS_TOKEN,
   appId: APP_ID,
   appSecret: APP_SECRET,
-  version: '3.3',
+  version: '4.0',
 });
 ```
 
-If it is not specified, version `3.3` will be used as default.
+If it is not specified, version `4.0` will be used as default.
 
 ### Verifying Graph API Calls with appsecret_proof
 

--- a/packages/messaging-api-messenger/src/MessengerClient.js
+++ b/packages/messaging-api-messenger/src/MessengerClient.js
@@ -104,7 +104,7 @@ function onRequest(request) {
 export default class MessengerClient {
   static connect(
     accessTokenOrConfig: string | ClientConfig,
-    version?: string = '3.3'
+    version?: string = '4.0'
   ): MessengerClient {
     return new MessengerClient(accessTokenOrConfig, version);
   }
@@ -123,7 +123,7 @@ export default class MessengerClient {
 
   constructor(
     accessTokenOrConfig: string | ClientConfig,
-    version?: string = '3.3'
+    version?: string = '4.0'
   ) {
     let origin;
     let skipAppSecretProof;
@@ -137,7 +137,7 @@ export default class MessengerClient {
       );
       this._appId = config.appId;
       this._appSecret = config.appSecret;
-      this._version = extractVersion(config.version || '3.3');
+      this._version = extractVersion(config.version || '4.0');
       this._onRequest = config.onRequest || onRequest;
       origin = config.origin;
 
@@ -1277,6 +1277,8 @@ export default class MessengerClient {
     messages: Array<Object> = [],
     { access_token: customAccessToken }: { access_token?: string } = {}
   ) {
+    warning(false, 'createMessageCreative: Broadcast API is deprecated.');
+
     return this._axios
       .post(
         `/me/message_creatives?access_token=${customAccessToken ||
@@ -1294,6 +1296,8 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/send-messages/broadcast-messages#sending
    */
   sendBroadcastMessage(messageCreativeId: number, options?: Object = {}) {
+    warning(false, 'sendBroadcastMessage: Broadcast API is deprecated.');
+
     return this._axios
       .post(
         `/me/broadcast_messages?access_token=${options.access_token ||
@@ -1307,6 +1311,8 @@ export default class MessengerClient {
   }
 
   cancelBroadcast(broadcastId: number, options?: Object = {}) {
+    warning(false, 'cancelBroadcast: Broadcast API is deprecated.');
+
     return this._axios
       .post(
         `/${broadcastId}?access_token=${options.access_token ||
@@ -1319,6 +1325,8 @@ export default class MessengerClient {
   }
 
   getBroadcast(broadcastId: number, options?: Object = {}) {
+    warning(false, 'getBroadcast: Broadcast API is deprecated.');
+
     return this._axios
       .get(
         `/${broadcastId}?fields=scheduled_time,status&access_token=${options.access_token ||
@@ -1489,6 +1497,8 @@ export default class MessengerClient {
     customLabelId: number,
     { access_token: customAccessToken }: { access_token?: string } = {}
   ) {
+    warning(false, 'startReachEstimation: Broadcast API is deprecated.');
+
     return this._axios
       .post(
         `/me/broadcast_reach_estimations?access_token=${customAccessToken ||
@@ -1509,6 +1519,8 @@ export default class MessengerClient {
     reachEstimationId: number,
     { access_token: customAccessToken }: { access_token?: string } = {}
   ) {
+    warning(false, 'getReachEstimate: Broadcast API is deprecated.');
+
     return this._axios
       .get(
         `/${reachEstimationId}?access_token=${customAccessToken ||
@@ -1527,6 +1539,8 @@ export default class MessengerClient {
     broadcastId: number,
     { access_token: customAccessToken }: { access_token?: string } = {}
   ) {
+    warning(false, 'getBroadcastMessagesSent: Broadcast API is deprecated.');
+
     return this._axios
       .post(
         `/${broadcastId}/insights/messages_sent?access_token=${customAccessToken ||
@@ -1615,6 +1629,8 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/discovery/messenger-codes
    */
   generateMessengerCode(options: Object = {}) {
+    warning(false, 'generateMessengerCode: Messenger Code is deprecated.');
+
     return this._axios
       .post(
         `/me/messenger_codes?access_token=${options.access_token ||

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.js
@@ -29,7 +29,7 @@ describe('connect', () => {
       MessengerClient.connect(ACCESS_TOKEN);
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v3.3/',
+        baseURL: 'https://graph.facebook.com/v4.0/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -45,7 +45,7 @@ describe('connect', () => {
       MessengerClient.connect({ accessToken: ACCESS_TOKEN });
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v3.3/',
+        baseURL: 'https://graph.facebook.com/v4.0/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -102,7 +102,7 @@ describe('connect', () => {
     });
 
     expect(axios.create).toBeCalledWith({
-      baseURL: 'https://mydummytestserver.com/v3.3/',
+      baseURL: 'https://mydummytestserver.com/v4.0/',
       headers: { 'Content-Type': 'application/json' },
     });
   });
@@ -121,7 +121,7 @@ describe('constructor', () => {
       new MessengerClient(ACCESS_TOKEN); // eslint-disable-line no-new
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v3.3/',
+        baseURL: 'https://graph.facebook.com/v4.0/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -137,7 +137,7 @@ describe('constructor', () => {
       new MessengerClient({ accessToken: ACCESS_TOKEN }); // eslint-disable-line no-new
 
       expect(axios.create).toBeCalledWith({
-        baseURL: 'https://graph.facebook.com/v3.3/',
+        baseURL: 'https://graph.facebook.com/v4.0/',
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -192,7 +192,7 @@ describe('constructor', () => {
     });
 
     expect(axios.create).toBeCalledWith({
-      baseURL: 'https://mydummytestserver.com/v3.3/',
+      baseURL: 'https://mydummytestserver.com/v4.0/',
       headers: { 'Content-Type': 'application/json' },
     });
   });
@@ -200,7 +200,7 @@ describe('constructor', () => {
 
 describe('#version', () => {
   it('should return version of graph api', () => {
-    expect(new MessengerClient(ACCESS_TOKEN).version).toEqual('3.3');
+    expect(new MessengerClient(ACCESS_TOKEN).version).toEqual('4.0');
     expect(new MessengerClient(ACCESS_TOKEN, 'v2.6').version).toEqual('2.6');
     expect(new MessengerClient(ACCESS_TOKEN, '2.6').version).toEqual('2.6');
     expect(() => {
@@ -209,7 +209,7 @@ describe('#version', () => {
     }).toThrow('Type of `version` must be string.');
 
     expect(new MessengerClient({ accessToken: ACCESS_TOKEN }).version).toEqual(
-      '3.3'
+      '4.0'
     );
     expect(
       new MessengerClient({ accessToken: ACCESS_TOKEN, version: 'v2.6' })
@@ -277,7 +277,7 @@ describe('#onRequest', () => {
 
     expect(onRequest).toBeCalledWith({
       method: 'post',
-      url: 'https://graph.facebook.com/v3.3/path',
+      url: 'https://graph.facebook.com/v4.0/path',
       body: {
         x: 1,
       },

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-persona.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-persona.spec.js
@@ -95,7 +95,7 @@ describe('persona api', () => {
             after: cursor,
           },
           next:
-            'https://graph.facebook.com/v3.3/138523840252451/personas?access_token=0987654321&limit=25&after=QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
+            'https://graph.facebook.com/v4.0/138523840252451/personas?access_token=0987654321&limit=25&after=QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
         },
       };
 
@@ -194,7 +194,7 @@ describe('persona api', () => {
               'QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
           },
           next:
-            'https://graph.facebook.com/v3.3/138523840252451/personas?access_token=0987654321&limit=25&after=QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
+            'https://graph.facebook.com/v4.0/138523840252451/personas?access_token=0987654321&limit=25&after=QVFIUl96LThrbmJrU3gzOHdsR2JaZA2dDM01uaEJNaUZArWnNTNHBhQi1iZA3lvakk2YWlUR3F5bUV3UDJYZAWVxYnJyOFA1VnJwZAG9GUEVzOGRMZAzRsV08wdW1R',
         },
       };
 

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.js
@@ -71,7 +71,7 @@ describe('token', () => {
 
       mock.onGet().reply(config => {
         expect(config.baseURL + config.url).toEqual(
-          'https://graph.facebook.com/v3.3/debug_token'
+          'https://graph.facebook.com/v4.0/debug_token'
         );
         expect(config.params).toEqual({
           input_token: ACCESS_TOKEN,


### PR DESCRIPTION
https://developers.facebook.com/docs/graph-api/changelog/version4.0#messenger

- use `4.0` as default version
- deprecations:
  - createMessageCreative
  - sendBroadcastMessage
  - cancelBroadcast
  - getBroadcast
  - generateMessengerCode
  - startReachEstimation
  - getReachEstimate
  - getBroadcastMessagesSent
  - generateMessengerCode