### PR TITLE
fix(debug): avoid print stringified buffer

### DIFF
--- a/packages/messaging-api-common/src/index.ts
+++ b/packages/messaging-api-common/src/index.ts
@@ -10,7 +10,11 @@ function onRequest(request: {
 }): void {
   if (request.body) {
     debugRequest('Outgoing request body:');
-    debugRequest(JSON.stringify(request.body, null, 2));
+    if (Buffer.isBuffer(request.body)) {
+      debugRequest(request.body);
+    } else {
+      debugRequest(JSON.stringify(request.body, null, 2));
+    }
   }
 }
 


### PR DESCRIPTION
This should prevent print a  shortened buffer instead of a spread one

before:
```
{
  "type": "Buffer",
  "data": [
    97,
    107,
    100,
    102,
    104,
    110,
    112,
    111,
    51,
    50,
    106,
    105,
    52,
    112,
    106,
    105,
    97,
    111,
    115,
    112,
    106,
    100,
    105,
    111,
    98,
    97,
    111,
    112,
    110,
    52,
    105,
    111,
    112,
    51,
    106,
    104,
    105,
    52,
    112,
    111,
    106,
    97,
    115,
    100,
    105,
    111,
    109,
    105,
    111,
    122,
    120,
    112,
    98,
    118,
    105,
    111,
    112,
    110,
    97,
    111,
    52,
    101,
    110,
    111,
    97,
    110,
    100,
    111,
    102
  ]
}
```

after:
```
<Buffer 61 6b 64 66 68 6e 70 6f 33 32 6a 69 34 70 6a 69 61 6f 73 70 6a 64 69 6f 62 61 6f 70 6e 34 69 6f 70 33 6a 68 69 34 70 6f 6a 61 73 64 69 6f 6d 69 6f 7a ... >
```

close #463 