### PR TITLE
add namespace to export types

### DIFF
--- a/packages/messaging-api-line/src/index.ts
+++ b/packages/messaging-api-line/src/index.ts
@@ -1,7 +1,6 @@
 import Line from './Line';
 import LineClient from './LineClient';
 import LinePay from './LinePay';
+import * as LineTypes from './LineTypes';
 
-export * from './LineTypes';
-
-export { Line, LineClient, LinePay };
+export { Line, LineClient, LinePay, LineTypes };

--- a/packages/messaging-api-messenger/src/index.ts
+++ b/packages/messaging-api-messenger/src/index.ts
@@ -2,7 +2,12 @@ import Messenger from './Messenger';
 import MessengerBatch from './MessengerBatch';
 import MessengerBroadcast from './MessengerBroadcast';
 import MessengerClient from './MessengerClient';
+import * as MessengerTypes from './MessengerTypes';
 
-export * from './MessengerTypes';
-
-export { Messenger, MessengerBatch, MessengerClient, MessengerBroadcast };
+export {
+  Messenger,
+  MessengerBatch,
+  MessengerClient,
+  MessengerBroadcast,
+  MessengerTypes,
+};

--- a/packages/messaging-api-slack/src/index.ts
+++ b/packages/messaging-api-slack/src/index.ts
@@ -1,6 +1,5 @@
 import SlackOAuthClient from './SlackOAuthClient';
 import SlackWebhookClient from './SlackWebhookClient';
+import * as SlackTypes from './SlackTypes';
 
-export * from './SlackTypes';
-
-export { SlackOAuthClient, SlackWebhookClient };
+export { SlackOAuthClient, SlackWebhookClient, SlackTypes };

--- a/packages/messaging-api-telegram/src/index.ts
+++ b/packages/messaging-api-telegram/src/index.ts
@@ -1,5 +1,4 @@
 import TelegramClient from './TelegramClient';
+import * as TelegramTypes from './TelegramTypes';
 
-export * from './TelegramTypes';
-
-export { TelegramClient };
+export { TelegramClient, TelegramTypes };

--- a/packages/messaging-api-viber/src/index.ts
+++ b/packages/messaging-api-viber/src/index.ts
@@ -1,5 +1,4 @@
 import ViberClient from './ViberClient';
+import * as ViberTypes from './ViberTypes';
 
-export * from './ViberTypes';
-
-export { ViberClient };
+export { ViberClient, ViberTypes };

--- a/packages/messaging-api-wechat/src/index.ts
+++ b/packages/messaging-api-wechat/src/index.ts
@@ -1,5 +1,4 @@
 import WechatClient from './WechatClient';
+import * as WechatTypes from './WechatTypes';
 
-export * from './WechatTypes';
-
-export { WechatClient };
+export { WechatClient, WechatTypes };


### PR DESCRIPTION
So it will be imported like this:

```js
import { MessengerClient, MessengerTypes } from 'messaging-api-messenger';
import { LineClient, LineTypes } from 'messaging-api-line';
import { TelegramClient, TelegramTypes } from 'messaging-api-telegram';
// ...
```