### PR TITLE
to avoid passing unsupported parameter

### DIFF
--- a/packages/messaging-api-telegram/src/TelegramClient.ts
+++ b/packages/messaging-api-telegram/src/TelegramClient.ts
@@ -6,6 +6,7 @@ import omit from 'lodash.omit';
 import snakeCaseKeys from 'snakecase-keys';
 import urlJoin from 'url-join';
 import { onRequest } from 'messaging-api-common';
+import { pick } from 'lodash';
 
 import {
   Chat,
@@ -149,9 +150,14 @@ export default class TelegramClient {
    * @returns True on success.
    */
   setWebhook(url: string, options: SetWebhookOption = {}): Promise<boolean> {
+    const optionsWithoutCertificate = pick(options, [
+      'maxConnections',
+      'allowedUpdates',
+    ]);
+    const snakecaseOptions = snakeCaseKeys(optionsWithoutCertificate);
     return this._request('/setWebhook', {
       url,
-      ...snakeCaseKeys(options),
+      ...snakecaseOptions,
     });
   }
 

--- a/packages/messaging-api-telegram/src/TelegramClient.ts
+++ b/packages/messaging-api-telegram/src/TelegramClient.ts
@@ -150,14 +150,14 @@ export default class TelegramClient {
    * @returns True on success.
    */
   setWebhook(url: string, options: SetWebhookOption = {}): Promise<boolean> {
-    const optionsWithoutCertificate = pick(options, [
-      'maxConnections',
-      'allowedUpdates',
+    const snakecaseOptions = snakeCaseKeys(options);
+    const optionsWithoutCertificate = pick(snakecaseOptions, [
+      'max_connections',
+      'allowed_updates',
     ]);
-    const snakecaseOptions = snakeCaseKeys(optionsWithoutCertificate);
     return this._request('/setWebhook', {
       url,
-      ...snakecaseOptions,
+      ...optionsWithoutCertificate,
     });
   }
 

--- a/packages/messaging-api-telegram/src/TelegramClient.ts
+++ b/packages/messaging-api-telegram/src/TelegramClient.ts
@@ -92,9 +92,9 @@ export default class TelegramClient {
     return this._token;
   }
 
-  async _request(path: string, body?: Record<string, any>) {
+  async _request(path: string, body: Record<string, any> = {}) {
     try {
-      const response = await this._axios.post(path, body);
+      const response = await this._axios.post(path, snakeCaseKeys(body));
 
       const { data, config, request } = response;
 
@@ -150,10 +150,11 @@ export default class TelegramClient {
    * @returns True on success.
    */
   setWebhook(url: string, options: SetWebhookOption = {}): Promise<boolean> {
-    const snakecaseOptions = snakeCaseKeys(options);
-    const optionsWithoutCertificate = pick(snakecaseOptions, [
+    const optionsWithoutCertificate = pick(options, [
       'max_connections',
       'allowed_updates',
+      'maxConnections',
+      'allowedUpdates',
     ]);
     return this._request('/setWebhook', {
       url,

--- a/packages/messaging-api-telegram/src/TelegramClient.ts
+++ b/packages/messaging-api-telegram/src/TelegramClient.ts
@@ -3,10 +3,10 @@
 import AxiosError from 'axios-error';
 import axios, { AxiosInstance } from 'axios';
 import omit from 'lodash.omit';
+import pick from 'lodash/pick';
 import snakeCaseKeys from 'snakecase-keys';
 import urlJoin from 'url-join';
 import { onRequest } from 'messaging-api-common';
-import { pick } from 'lodash';
 
 import {
   Chat,

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.ts
@@ -127,6 +127,32 @@ describe('webhooks', () => {
 
       expect(res).toEqual(result);
     });
+
+    it('should ignore certificate options and transform all options to snakecase', async () => {
+      const { client, mock } = createMock();
+      const result = true;
+      const reply = {
+        ok: true,
+        result,
+        description: 'Webhook was set',
+      };
+
+      mock
+        .onPost('/setWebhook', {
+          url: 'https://4a16faff.ngrok.io/',
+          max_connections: 40,
+          allowed_updates: [],
+        })
+        .reply(200, reply);
+
+      const res = await client.setWebhook('https://4a16faff.ngrok.io/', {
+        certificate: 'qq',
+        maxConnections: 40,
+        allowedUpdates: [],
+      });
+
+      expect(res).toEqual(result);
+    });
   });
 
   describe('#deleteWebhook', () => {

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.ts
@@ -112,15 +112,15 @@ describe('webhooks', () => {
   });
 
   describe('#setWebhook', () => {
+    const result = true;
+    const reply = {
+      ok: true,
+      result,
+      description: 'Webhook was set',
+    };
+
     it('should response webhook was set', async () => {
       const { client, mock } = createMock();
-      const result = true;
-      const reply = {
-        ok: true,
-        result,
-        description: 'Webhook was set',
-      };
-
       mock.onPost('/setWebhook').reply(200, reply);
 
       const res = await client.setWebhook('https://4a16faff.ngrok.io/');
@@ -130,13 +130,6 @@ describe('webhooks', () => {
 
     it('should ignore certificate options and transform all options to snakecase', async () => {
       const { client, mock } = createMock();
-      const result = true;
-      const reply = {
-        ok: true,
-        result,
-        description: 'Webhook was set',
-      };
-
       mock
         .onPost('/setWebhook', {
           url: 'https://4a16faff.ngrok.io/',
@@ -149,6 +142,25 @@ describe('webhooks', () => {
         certificate: 'qq',
         maxConnections: 40,
         allowedUpdates: [],
+      });
+
+      expect(res).toEqual(result);
+    });
+
+    it('should work well with snakecase options', async () => {
+      const { client, mock } = createMock();
+      mock
+        .onPost('/setWebhook', {
+          url: 'https://4a16faff.ngrok.io/',
+          max_connections: 40,
+          allowed_updates: [],
+        })
+        .reply(200, reply);
+
+      const res = await client.setWebhook('https://4a16faff.ngrok.io/', {
+        certificate: 'qq',
+        max_connections: 40,
+        allowed_updates: [],
       });
 
       expect(res).toEqual(result);


### PR DESCRIPTION
Remove options.certificate of Telegram#setWebhook before sending the request with testing code.
