### PR TITLE
chore: replace Telegram#forwardMessage option type to ForwardMessageOption

### DIFF
--- a/packages/messaging-api-telegram/src/TelegramClient.ts
+++ b/packages/messaging-api-telegram/src/TelegramClient.ts
@@ -13,6 +13,7 @@ import {
   ChatAction,
   ChatMember,
   File,
+  ForwardMessageOption,
   GameHighScore,
   GetUpdatesOption,
   Message,
@@ -205,18 +206,24 @@ export default class TelegramClient {
   }
 
   /**
-   * https://core.telegram.org/bots/api#getchatmemberscount
+   * Use this method to forward messages of any kind. On success, the sent Message is returned.
+   *
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param fromChatId Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
+   * @param messageId Message identifier in the chat specified in from_chat_id
+   * @param options.disableNotification Sends the message silently. Users will receive a notification with no sound
+   * https://core.telegram.org/bots/api#forwardmessage
    */
   forwardMessage(
-    chatId: string,
-    fromChatId: string,
+    chatId: string | number,
+    fromChatId: string | number,
     messageId: number,
-    options?: Record<string, any>
+    options?: ForwardMessageOption
   ): Promise<Message> {
     return this._request('/forwardMessage', {
-      chat_id: chatId,
-      from_chat_id: fromChatId,
-      message_id: messageId,
+      chatId,
+      fromChatId,
+      messageId,
       ...options,
     });
   }

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.ts
@@ -514,36 +514,36 @@ describe('inline mode api', () => {
 
 describe('other api', () => {
   describe('#forwardMessage', () => {
-    it('should forward messages of any kind', async () => {
-      const { client, mock } = createMock();
-      const result = {
-        message_id: 1,
-        from: {
-          id: 313534466,
-          first_name: 'first',
-          username: 'a_bot',
-        },
-        chat: {
-          id: 427770117,
-          first_name: 'first',
-          last_name: 'last',
-          type: 'private',
-        },
-        date: 1499402829,
-        forward_from: {
-          id: 357830311,
-          first_name: 'first_2',
-          last_name: 'last_2',
-          language_code: 'zh-TW',
-        },
-        forward_date: 1499849644,
-        text: 'hi',
-      };
-      const reply = {
-        ok: true,
-        result,
-      };
+    const result = {
+      message_id: 1,
+      from: {
+        id: 313534466,
+        first_name: 'first',
+        username: 'a_bot',
+      },
+      chat: {
+        id: 427770117,
+        first_name: 'first',
+        last_name: 'last',
+        type: 'private',
+      },
+      date: 1499402829,
+      forward_from: {
+        id: 357830311,
+        first_name: 'first_2',
+        last_name: 'last_2',
+        language_code: 'zh-TW',
+      },
+      forward_date: 1499849644,
+      text: 'hi',
+    };
+    const reply = {
+      ok: true,
+      result,
+    };
 
+    it('should forward messages of any kind with snakecase', async () => {
+      const { client, mock } = createMock();
       mock
         .onPost('/forwardMessage', {
           chat_id: 427770117,
@@ -555,6 +555,23 @@ describe('other api', () => {
 
       const res = await client.forwardMessage(427770117, 313534466, 203, {
         disable_notification: true,
+      });
+
+      expect(res).toEqual(result);
+    });
+    it('should forward messages of any kind with camelcase', async () => {
+      const { client, mock } = createMock();
+      mock
+        .onPost('/forwardMessage', {
+          chat_id: 427770117,
+          from_chat_id: 313534466,
+          message_id: 203,
+          disable_notification: true,
+        })
+        .reply(200, reply);
+
+      const res = await client.forwardMessage(427770117, 313534466, 203, {
+        disableNotification: true,
       });
 
       expect(res).toEqual(result);


### PR DESCRIPTION
Replaced Telegram#forwardMessage option type to ForwardMessageOption.
Allowed snake case and camelcase option.
Added related comments and testing code.