### PR TITLE
replace TelegramClient#sendAudio with SendAudioOption

### DIFF
--- a/packages/messaging-api-telegram/src/TelegramClient.ts
+++ b/packages/messaging-api-telegram/src/TelegramClient.ts
@@ -220,7 +220,7 @@ export default class TelegramClient {
    * Use this method to send photos. On success, the sent Message is returned.
    *
    * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-   * @param photo Photo to send. Pass a file_id as String to send a photo that exists on the Telegram servers (recommended) or pass an HTTP URL as a String for Telegram to get a photo from the Internet. upload file is not supported yet.
+   * @param photo Photo to send. Pass a file_id as String to send a photo that exists on the Telegram servers (recommended) or pass an HTTP URL as a String for Telegram to get a photo from the Internet. Upload file is not supported yet.
    * @param options Options for other optional parameters.
    *
    * - https://core.telegram.org/bots/api#sendphoto
@@ -238,17 +238,39 @@ export default class TelegramClient {
   }
 
   /**
-   * https://core.telegram.org/bots/api#sendaudio
+   * Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
+   *
+   * For sending voice messages, use the sendVoice method instead.
+   *
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param audio Audio file to send. Pass a file_id as String to send an audio file that exists on the Telegram servers (recommended) or pass an HTTP URL as a String for Telegram to get an audio file from the Internet. Upload file is not supported yet.
+   * @param options Options for other optional parameters.
+   *
+   * - https://core.telegram.org/bots/api#sendaudio
    */
   sendAudio(
-    chatId: string,
+    chatId: string | number,
     audio: string,
-    options?: Record<string, any>
+    options?: Type.SendAudioOption
   ): Promise<Type.Message> {
+    const optionsWithoutThumb = pick(options, [
+      'caption',
+      'parse_mode',
+      'parseMode',
+      'duration',
+      'performer',
+      'title',
+      'disable_notification',
+      'disableNotification',
+      'reply_to_message_id',
+      'replyToMessageId',
+      'reply_markup',
+      'replyMarkup',
+    ]);
     return this._request('/sendAudio', {
-      chat_id: chatId,
+      chatId,
       audio,
-      ...options,
+      ...optionsWithoutThumb,
     });
   }
 

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient-send.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient-send.spec.ts
@@ -359,43 +359,49 @@ describe('send api', () => {
   });
 
   describe('#sendAudio', () => {
-    it('should send audio message to user', async () => {
+    const result = {
+      message_id: 1,
+      from: {
+        id: 313534466,
+        first_name: 'first',
+        username: 'a_bot',
+      },
+      chat: {
+        id: 427770117,
+        first_name: 'first',
+        last_name: 'last',
+        type: 'private',
+      },
+      date: 1499403678,
+      audio: {
+        duration: 108,
+        mime_type: 'audio/mpeg',
+        title: 'Song_Title',
+        performer: 'Song_Performer',
+        file_id: 'CQADBAADgJMAAkIeZAdcAAGmY-4zEngC',
+        file_size: 1739320,
+      },
+      caption: 'gooooooodAudio',
+    };
+    const reply = {
+      ok: true,
+      result,
+    };
+
+    it('should send audio message to user with snakecase', async () => {
       const { client, mock } = createMock();
-      const result = {
-        message_id: 1,
-        from: {
-          id: 313534466,
-          first_name: 'first',
-          username: 'a_bot',
-        },
-        chat: {
-          id: 427770117,
-          first_name: 'first',
-          last_name: 'last',
-          type: 'private',
-        },
-        date: 1499403678,
-        audio: {
-          duration: 108,
-          mime_type: 'audio/mpeg',
-          title: 'Song_Title',
-          performer: 'Song_Performer',
-          file_id: 'CQADBAADgJMAAkIeZAdcAAGmY-4zEngC',
-          file_size: 1739320,
-        },
-        caption: 'gooooooodAudio',
-      };
-      const reply = {
-        ok: true,
-        result,
-      };
 
       mock
         .onPost('/sendAudio', {
           chat_id: 427770117,
           audio: 'https://example.com/audio.mp3',
           caption: 'gooooooodAudio',
+          parse_mode: 'Markdown',
+          duration: 1,
+          performer: 'performer',
+          title: 'title',
           disable_notification: true,
+          reply_to_message_id: 9527,
         })
         .reply(200, reply);
 
@@ -404,7 +410,48 @@ describe('send api', () => {
         'https://example.com/audio.mp3',
         {
           caption: 'gooooooodAudio',
+          parse_mode: 'Markdown',
+          duration: 1,
+          performer: 'performer',
+          title: 'title',
+          thumb: 'thumb',
           disable_notification: true,
+          reply_to_message_id: 9527,
+        }
+      );
+
+      expect(res).toEqual(result);
+    });
+
+    it('should send audio message to user with camelcase', async () => {
+      const { client, mock } = createMock();
+
+      mock
+        .onPost('/sendAudio', {
+          chat_id: 427770117,
+          audio: 'https://example.com/audio.mp3',
+          caption: 'gooooooodAudio',
+          parse_mode: 'Markdown',
+          duration: 1,
+          performer: 'performer',
+          title: 'title',
+          disable_notification: true,
+          reply_to_message_id: 9527,
+        })
+        .reply(200, reply);
+
+      const res = await client.sendAudio(
+        427770117,
+        'https://example.com/audio.mp3',
+        {
+          caption: 'gooooooodAudio',
+          parseMode: ParseMode.Markdown,
+          duration: 1,
+          performer: 'performer',
+          title: 'title',
+          thumb: 'thumb',
+          disableNotification: true,
+          replyToMessageId: 9527,
         }
       );
 


### PR DESCRIPTION
Please merge this one first: https://github.com/Yoctol/messaging-apis/pull/495

- prevent option thumb pass to Telegram Bot API
- with related tests.