### PR TITLE
fix(LineClient): handle arraybuffer correctly in retrieveMessageContent

### DIFF
--- a/packages/messaging-api-line/src/LineClient.js
+++ b/packages/messaging-api-line/src/LineClient.js
@@ -564,14 +564,13 @@ export default class LineClient {
     { accessToken: customAccessToken }: { accessToken?: string } = {}
   ): Promise<Buffer> {
     return this._axios
-      .get(
-        `/v2/bot/message/${messageId}/content`,
-        customAccessToken && {
-          responseType: 'arraybuffer',
-          headers: { Authorization: `Bearer ${customAccessToken}` },
-        }
-      )
-      .then(res => Buffer.from(res.data), handleError);
+      .get(`/v2/bot/message/${messageId}/content`, {
+        responseType: 'arraybuffer',
+        ...(customAccessToken
+          ? { headers: { Authorization: `Bearer ${customAccessToken}` } }
+          : undefined),
+      })
+      .then(res => res.data, handleError);
   }
 
   /**


### PR DESCRIPTION
close #479, close #480

See: https://github.com/Yoctol/messaging-apis/issues/479#issuecomment-536156104