### PR TITLE
fix(WechatClient): apply throwErrorIfAny to getAccessToken

### DIFF
--- a/packages/messaging-api-wechat/src/WechatClient.js
+++ b/packages/messaging-api-wechat/src/WechatClient.js
@@ -153,6 +153,7 @@ export default class WechatClient {
       .get(
         `/token?grant_type=client_credential&appid=${this._appId}&secret=${this._appSecret}`
       )
+      .then(throwErrorIfAny)
       .then(res => res.data);
   }
 


### PR DESCRIPTION
#439

- apply throwErrorIfAny to `getAccessToken`, so we can get following errors instead of `invalid credential, access_token is invalid or not latest`:

When `appId` is wrong:

```
{
  "errcode": 40013,
  "errmsg": "invalid appid hint: [7Bj.La0878e508]"
}
```

When `appSecret` is wrong:

```
{
  "errcode": 40125,
  "errmsg": "invalid appsecret, view more at http://t.cn/RAEkdVq hint: [cE6IAA01601533]"
}
```