### PR TITLE
feat: Add name to AxiosError instances

### DIFF
--- a/packages/axios-error/src/__tests__/index.spec.ts
+++ b/packages/axios-error/src/__tests__/index.spec.ts
@@ -32,6 +32,7 @@ it('should work', async () => {
     error.stack = stack;
 
     expect(error[util.inspect.custom]()).toMatchSnapshot();
+    expect(error.name).toBe('AxiosError');
   }
 });
 
@@ -61,6 +62,7 @@ it('should work with construct using error instance only', async () => {
     error.stack = stack;
 
     expect(error[util.inspect.custom]()).toMatchSnapshot();
+    expect(error.name).toBe('AxiosError');
   }
 });
 
@@ -78,6 +80,7 @@ it('should work with undefined response', async () => {
     error.stack = stack;
 
     expect(error[util.inspect.custom]()).toMatchSnapshot();
+    expect(error.name).toBe('AxiosError');
   }
 });
 
@@ -86,4 +89,5 @@ it('should support error without axios data', () => {
   error.stack = stack;
 
   expect(error[util.inspect.custom]()).toMatchSnapshot();
+  expect(error.name).toBe('AxiosError');
 });

--- a/packages/axios-error/src/index.ts
+++ b/packages/axios-error/src/index.ts
@@ -43,6 +43,8 @@ export default class AxiosError extends Error {
     if (response && response.status) {
       this.status = response.status;
     }
+
+    this.name = 'AxiosError';
   }
 
   [util.inspect.custom](): string {


### PR DESCRIPTION
this will be better on error tracking services like Sentry or when you want to check error type by `.name`

ref: https://github.com/sindresorhus/aggregate-error/blob/master/index.js#L35