### PR TITLE
fix: replace typecheck with compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:staged": "lint-staged",
     "publish": "lerna publish",
     "prepublishOnly": "yarn clean && yarn && yarn test",
-    "test": "yarn typecheck && yarn lint && yarn testonly",
+    "test": "yarn compile && yarn lint && yarn testonly",
     "testonly": "jest --verbose",
     "testonly:cov": "jest --verbose --coverage --runInBand --forceExit --no-cache",
     "testonly:watch": "jest --verbose --watchAll",


### PR DESCRIPTION
We don't have a `typecheck` script now, so replace it with `compile`.