### PR TITLE
changed(LineClient): rename issueLinkToken to getLinkToken and return a string

### DIFF
--- a/packages/messaging-api-line/src/LineClient.ts
+++ b/packages/messaging-api-line/src/LineClient.ts
@@ -1293,9 +1293,13 @@ export default class LineClient {
   issueLinkToken(
     userId: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<{ issueToken: string }> {
+  ): Promise<{ linkToken: string }> {
+    warning(
+      false,
+      '`issueLinkToken` is deprecated. Use `getLinkToken` instead. Note: It returns a string instead of an object.'
+    );
     return this._axios
-      .post(
+      .post<{ linkToken: string }>(
         `/v2/bot/user/${userId}/linkToken`,
         null,
         customAccessToken
@@ -1305,6 +1309,23 @@ export default class LineClient {
           : {}
       )
       .then(res => res.data, handleError);
+  }
+
+  getLinkToken(
+    userId: string,
+    { accessToken: customAccessToken }: { accessToken?: string } = {}
+  ): Promise<string> {
+    return this._axios
+      .post<{ linkToken: string }>(
+        `/v2/bot/user/${userId}/linkToken`,
+        null,
+        customAccessToken
+          ? {
+              headers: { Authorization: `Bearer ${customAccessToken}` },
+            }
+          : {}
+      )
+      .then(res => res.data.linkToken, handleError);
   }
 
   /**

--- a/packages/messaging-api-line/src/__tests__/LineClient.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient.spec.ts
@@ -118,7 +118,7 @@ describe('Profile', () => {
 });
 
 describe('Account link', () => {
-  describe('#issueLinkToken', () => {
+  describe('#getLinkToken', () => {
     it('should response data with link token', async () => {
       expect.assertions(4);
 
@@ -136,9 +136,9 @@ describe('Account link', () => {
         return [200, reply];
       });
 
-      const res = await client.issueLinkToken(RECIPIENT_ID);
+      const res = await client.getLinkToken(RECIPIENT_ID);
 
-      expect(res).toEqual(reply);
+      expect(res).toEqual('NMZTNuVrPTqlr2IF8Bnymkb7rXfYv5EY');
     });
 
     it('should work with custom access token', async () => {
@@ -160,11 +160,11 @@ describe('Account link', () => {
         return [200, reply];
       });
 
-      const res = await client.issueLinkToken(RECIPIENT_ID, {
+      const res = await client.getLinkToken(RECIPIENT_ID, {
         accessToken: CUSTOM_ACCESS_TOKEN,
       });
 
-      expect(res).toEqual(reply);
+      expect(res).toEqual('NMZTNuVrPTqlr2IF8Bnymkb7rXfYv5EY');
     });
   });
 });


### PR DESCRIPTION
Our goal is making develops who familiar with LINE Node.js SDK can migrate their apps to our Bottender framework easily, so it's a reasonable change. 