### PR TITLE
refactor: use same way to import types

### DIFF
--- a/packages/messaging-api-line/src/Line.ts
+++ b/packages/messaging-api-line/src/Line.ts
@@ -1,30 +1,11 @@
 import omit from 'lodash/omit';
 
-import {
-  AudioMessage,
-  ButtonsTemplate,
-  CarouselTemplate,
-  ColumnObject,
-  ConfirmTemplate,
-  FlexContainer,
-  FlexMessage,
-  ImageCarouselColumnObject,
-  ImageCarouselTemplate,
-  ImageMessage,
-  ImagemapMessage,
-  Location,
-  LocationMessage,
-  MessageOptions,
-  QuickReply,
-  StickerMessage,
-  Template,
-  TemplateAction,
-  TemplateMessage,
-  TextMessage,
-  VideoMessage,
-} from './LineTypes';
+import * as Types from './LineTypes';
 
-function createText(text: string, options: MessageOptions = {}): TextMessage {
+function createText(
+  text: string,
+  options: Types.MessageOptions = {}
+): Types.TextMessage {
   return {
     type: 'text',
     text,
@@ -37,8 +18,8 @@ function createImage(
     originalContentUrl: string;
     previewImageUrl?: string;
   },
-  options: MessageOptions = {}
-): ImageMessage {
+  options: Types.MessageOptions = {}
+): Types.ImageMessage {
   return {
     type: 'image',
     originalContentUrl: image.originalContentUrl,
@@ -52,8 +33,8 @@ function createVideo(
     originalContentUrl: string;
     previewImageUrl: string;
   },
-  options: MessageOptions = {}
-): VideoMessage {
+  options: Types.MessageOptions = {}
+): Types.VideoMessage {
   return {
     type: 'video',
     originalContentUrl: video.originalContentUrl,
@@ -67,8 +48,8 @@ function createAudio(
     originalContentUrl: string;
     duration: number;
   },
-  options: MessageOptions = {}
-): AudioMessage {
+  options: Types.MessageOptions = {}
+): Types.AudioMessage {
   return {
     type: 'audio',
     originalContentUrl: audio.originalContentUrl,
@@ -78,9 +59,9 @@ function createAudio(
 }
 
 function createLocation(
-  { title, address, latitude, longitude }: Location,
-  options: MessageOptions = {}
-): LocationMessage {
+  { title, address, latitude, longitude }: Types.Location,
+  options: Types.MessageOptions = {}
+): Types.LocationMessage {
   return {
     type: 'location',
     title,
@@ -92,9 +73,9 @@ function createLocation(
 }
 
 function createSticker(
-  sticker: Omit<StickerMessage, 'type'>,
-  options: MessageOptions = {}
-): StickerMessage {
+  sticker: Omit<Types.StickerMessage, 'type'>,
+  options: Types.MessageOptions = {}
+): Types.StickerMessage {
   return {
     type: 'sticker',
     packageId: sticker.packageId,
@@ -110,9 +91,9 @@ function createImagemap(
     baseSize,
     video,
     actions,
-  }: Omit<ImagemapMessage, 'type' | 'altText'>,
-  options: MessageOptions = {}
-): ImagemapMessage {
+  }: Omit<Types.ImagemapMessage, 'type' | 'altText'>,
+  options: Types.MessageOptions = {}
+): Types.ImagemapMessage {
   return {
     type: 'imagemap',
     baseUrl,
@@ -126,9 +107,9 @@ function createImagemap(
 
 function createTemplate(
   altText: string,
-  template: Template,
-  options: MessageOptions = {}
-): TemplateMessage<any> {
+  template: Types.Template,
+  options: Types.MessageOptions = {}
+): Types.TemplateMessage<any> {
   return {
     type: 'template',
     altText,
@@ -155,11 +136,11 @@ function createButtonTemplate(
     imageBackgroundColor?: string;
     title?: string;
     text: string;
-    defaultAction?: TemplateAction;
-    actions: TemplateAction[];
+    defaultAction?: Types.TemplateAction;
+    actions: Types.TemplateAction[];
   },
-  options: MessageOptions = {}
-): TemplateMessage<ButtonsTemplate> {
+  options: Types.MessageOptions = {}
+): Types.TemplateMessage<Types.ButtonsTemplate> {
   return createTemplate(
     altText,
     {
@@ -184,10 +165,10 @@ function createConfirmTemplate(
     actions,
   }: {
     text: string;
-    actions: TemplateAction[];
+    actions: Types.TemplateAction[];
   },
-  options: MessageOptions = {}
-): TemplateMessage<ConfirmTemplate> {
+  options: Types.MessageOptions = {}
+): Types.TemplateMessage<Types.ConfirmTemplate> {
   return createTemplate(
     altText,
     {
@@ -201,7 +182,7 @@ function createConfirmTemplate(
 
 function createCarouselTemplate(
   altText: string,
-  columns: ColumnObject[],
+  columns: Types.ColumnObject[],
   {
     imageAspectRatio,
     imageSize,
@@ -209,9 +190,9 @@ function createCarouselTemplate(
   }: {
     imageAspectRatio?: 'rectangle' | 'square';
     imageSize?: 'cover' | 'contain';
-    quickReply?: QuickReply;
+    quickReply?: Types.QuickReply;
   } = {}
-): TemplateMessage<CarouselTemplate> {
+): Types.TemplateMessage<Types.CarouselTemplate> {
   return createTemplate(
     altText,
     {
@@ -226,9 +207,9 @@ function createCarouselTemplate(
 
 function createImageCarouselTemplate(
   altText: string,
-  columns: ImageCarouselColumnObject[],
-  options: MessageOptions = {}
-): TemplateMessage<ImageCarouselTemplate> {
+  columns: Types.ImageCarouselColumnObject[],
+  options: Types.MessageOptions = {}
+): Types.TemplateMessage<Types.ImageCarouselTemplate> {
   return createTemplate(
     altText,
     {
@@ -241,9 +222,9 @@ function createImageCarouselTemplate(
 
 function createFlex(
   altText: string,
-  contents: FlexContainer,
-  options: MessageOptions = {}
-): FlexMessage {
+  contents: Types.FlexContainer,
+  options: Types.MessageOptions = {}
+): Types.FlexMessage {
   return {
     type: 'flex',
     altText,

--- a/packages/messaging-api-line/src/LineClient.ts
+++ b/packages/messaging-api-line/src/LineClient.ts
@@ -9,36 +9,7 @@ import {
 } from 'messaging-api-common';
 
 import Line from './Line';
-import {
-  ButtonsTemplate,
-  ColumnObject,
-  ConfirmTemplate,
-  FlexContainer,
-  FriendDemographics,
-  ImageCarouselColumnObject,
-  ImagemapMessage,
-  LiffView,
-  Location,
-  Message,
-  MessageOptions,
-  MutationSuccessResponse,
-  NumberOfFollowersResponse,
-  NumberOfMessageDeliveriesResponse,
-  NumberOfMessagesSentResponse,
-  NumberOfMessagesSentThisMonth,
-  RichMenu,
-  StickerMessage,
-  TargetLimitForAdditionalMessages,
-  Template,
-  User,
-} from './LineTypes';
-
-type ClientConfig = {
-  accessToken: string;
-  channelSecret: string;
-  origin?: string;
-  onRequest?: OnRequestFunction;
-};
+import * as Types from './LineTypes';
 
 function handleError(err: {
   message: string;
@@ -67,7 +38,7 @@ function handleError(err: {
 
 export default class LineClient {
   static connect(
-    accessTokenOrConfig: string | ClientConfig,
+    accessTokenOrConfig: string | Types.ClientConfig,
     channelSecret?: string
   ): LineClient {
     return new LineClient(accessTokenOrConfig, channelSecret);
@@ -82,7 +53,7 @@ export default class LineClient {
   _accessToken: string;
 
   constructor(
-    accessTokenOrConfig: string | ClientConfig,
+    accessTokenOrConfig: string | Types.ClientConfig,
     channelSecret?: string
   ) {
     let origin;
@@ -127,10 +98,10 @@ export default class LineClient {
   replyRawBody(
     body: {
       replyToken: string;
-      messages: Message[];
+      messages: Types.Message[];
     },
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this._axios
       .post(
         '/v2/bot/message/reply',
@@ -146,25 +117,25 @@ export default class LineClient {
 
   reply(
     replyToken: string,
-    messages: Message[],
+    messages: Types.Message[],
     options?: Record<string, any>
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this.replyRawBody({ replyToken, messages }, options);
   }
 
   replyMessages(
     replyToken: string,
-    messages: Message[],
+    messages: Types.Message[],
     options?: Record<string, any>
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(replyToken, messages, options);
   }
 
   replyText(
     replyToken: string,
     text: string,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(replyToken, [Line.createText(text, options)], options);
   }
 
@@ -174,8 +145,8 @@ export default class LineClient {
       originalContentUrl: string;
       previewImageUrl?: string;
     },
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(replyToken, [Line.createImage(image, options)], options);
   }
 
@@ -185,8 +156,8 @@ export default class LineClient {
       originalContentUrl: string;
       previewImageUrl: string;
     },
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(replyToken, [Line.createVideo(video, options)], options);
   }
 
@@ -196,16 +167,16 @@ export default class LineClient {
       originalContentUrl: string;
       duration: number;
     },
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(replyToken, [Line.createAudio(audio, options)], options);
   }
 
   replyLocation(
     replyToken: string,
-    location: Location,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    location: Types.Location,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(
       replyToken,
       [Line.createLocation(location, options)],
@@ -215,9 +186,9 @@ export default class LineClient {
 
   replySticker(
     replyToken: string,
-    sticker: Omit<StickerMessage, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    sticker: Omit<Types.StickerMessage, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(
       replyToken,
       [Line.createSticker(sticker, options)],
@@ -233,9 +204,9 @@ export default class LineClient {
   replyImagemap(
     replyToken: string,
     altText: string,
-    imagemap: Omit<ImagemapMessage, 'type' | 'altText'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    imagemap: Omit<Types.ImagemapMessage, 'type' | 'altText'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(
       replyToken,
       [Line.createImagemap(altText, imagemap, options)],
@@ -251,9 +222,9 @@ export default class LineClient {
   replyFlex(
     replyToken: string,
     altText: string,
-    flex: FlexContainer,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    flex: Types.FlexContainer,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(
       replyToken,
       [Line.createFlex(altText, flex, options)],
@@ -269,9 +240,9 @@ export default class LineClient {
   replyTemplate(
     replyToken: string,
     altText: string,
-    template: Template,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    template: Types.Template,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(
       replyToken,
       [Line.createTemplate(altText, template, options)],
@@ -282,9 +253,9 @@ export default class LineClient {
   replyButtonTemplate(
     replyToken: string,
     altText: string,
-    buttonTemplate: Omit<ButtonsTemplate, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    buttonTemplate: Omit<Types.ButtonsTemplate, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(
       replyToken,
       [Line.createButtonTemplate(altText, buttonTemplate, options)],
@@ -295,9 +266,9 @@ export default class LineClient {
   replyButtonsTemplate(
     replyToken: string,
     altText: string,
-    buttonTemplate: Omit<ButtonsTemplate, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    buttonTemplate: Omit<Types.ButtonsTemplate, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.replyButtonTemplate(
       replyToken,
       altText,
@@ -309,9 +280,9 @@ export default class LineClient {
   replyConfirmTemplate(
     replyToken: string,
     altText: string,
-    confirmTemplate: Omit<ConfirmTemplate, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    confirmTemplate: Omit<Types.ConfirmTemplate, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(
       replyToken,
       [Line.createConfirmTemplate(altText, confirmTemplate, options)],
@@ -322,7 +293,7 @@ export default class LineClient {
   replyCarouselTemplate(
     replyToken: string,
     altText: string,
-    columns: ColumnObject[],
+    columns: Types.ColumnObject[],
     {
       imageAspectRatio,
       imageSize,
@@ -330,8 +301,8 @@ export default class LineClient {
     }: {
       imageAspectRatio?: 'rectangle' | 'square';
       imageSize?: 'cover' | 'contain';
-    } & MessageOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    } & Types.MessageOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(
       replyToken,
       [
@@ -348,9 +319,9 @@ export default class LineClient {
   replyImageCarouselTemplate(
     replyToken: string,
     altText: string,
-    columns: ImageCarouselColumnObject[],
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    columns: Types.ImageCarouselColumnObject[],
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.reply(
       replyToken,
       [Line.createImageCarouselTemplate(altText, columns, options)],
@@ -366,10 +337,10 @@ export default class LineClient {
   pushRawBody(
     body: {
       to: string;
-      messages: Message[];
+      messages: Types.Message[];
     },
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this._axios
       .post(
         '/v2/bot/message/push',
@@ -385,25 +356,25 @@ export default class LineClient {
 
   push(
     to: string,
-    messages: Message[],
+    messages: Types.Message[],
     options?: Record<string, any>
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this.pushRawBody({ to, messages }, options);
   }
 
   pushMessages(
     to: string,
-    messages: Message[],
+    messages: Types.Message[],
     options?: Record<string, any>
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(to, messages, options);
   }
 
   pushText(
     to: string,
     text: string,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(to, [Line.createText(text, options)], options);
   }
 
@@ -413,8 +384,8 @@ export default class LineClient {
       originalContentUrl: string;
       previewImageUrl?: string;
     },
-    options: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(to, [Line.createImage(image, options)], options);
   }
 
@@ -424,8 +395,8 @@ export default class LineClient {
       originalContentUrl: string;
       previewImageUrl: string;
     },
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(to, [Line.createVideo(video, options)], options);
   }
 
@@ -435,24 +406,24 @@ export default class LineClient {
       originalContentUrl: string;
       duration: number;
     },
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(to, [Line.createAudio(audio, options)], options);
   }
 
   pushLocation(
     to: string,
-    location: Location,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    location: Types.Location,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(to, [Line.createLocation(location, options)], options);
   }
 
   pushSticker(
     to: string,
-    sticker: Omit<StickerMessage, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    sticker: Omit<Types.StickerMessage, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(to, [Line.createSticker(sticker, options)], options);
   }
 
@@ -464,9 +435,9 @@ export default class LineClient {
   pushImagemap(
     to: string,
     altText: string,
-    imagemap: Omit<ImagemapMessage, 'type' | 'altText'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    imagemap: Omit<Types.ImagemapMessage, 'type' | 'altText'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(
       to,
       [Line.createImagemap(altText, imagemap, options)],
@@ -482,9 +453,9 @@ export default class LineClient {
   pushFlex(
     to: string,
     altText: string,
-    flex: FlexContainer,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    flex: Types.FlexContainer,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(to, [Line.createFlex(altText, flex, options)], options);
   }
 
@@ -496,9 +467,9 @@ export default class LineClient {
   pushTemplate(
     to: string,
     altText: string,
-    template: Template,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    template: Types.Template,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(
       to,
       [Line.createTemplate(altText, template, options)],
@@ -509,9 +480,9 @@ export default class LineClient {
   pushButtonTemplate(
     to: string,
     altText: string,
-    buttonTemplate: Omit<ButtonsTemplate, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    buttonTemplate: Omit<Types.ButtonsTemplate, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(
       to,
       [Line.createButtonTemplate(altText, buttonTemplate, options)],
@@ -522,18 +493,18 @@ export default class LineClient {
   pushButtonsTemplate(
     to: string,
     altText: string,
-    buttonTemplate: Omit<ButtonsTemplate, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    buttonTemplate: Omit<Types.ButtonsTemplate, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.pushButtonTemplate(to, altText, buttonTemplate, options);
   }
 
   pushConfirmTemplate(
     to: string,
     altText: string,
-    confirmTemplate: Omit<ConfirmTemplate, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    confirmTemplate: Omit<Types.ConfirmTemplate, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(
       to,
       [Line.createConfirmTemplate(altText, confirmTemplate, options)],
@@ -544,7 +515,7 @@ export default class LineClient {
   pushCarouselTemplate(
     to: string,
     altText: string,
-    columns: ColumnObject[],
+    columns: Types.ColumnObject[],
     {
       imageAspectRatio,
       imageSize,
@@ -552,8 +523,8 @@ export default class LineClient {
     }: {
       imageAspectRatio?: 'rectangle' | 'square';
       imageSize?: 'cover' | 'contain';
-    } & MessageOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    } & Types.MessageOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(
       to,
       [
@@ -570,9 +541,9 @@ export default class LineClient {
   pushImageCarouselTemplate(
     to: string,
     altText: string,
-    columns: ImageCarouselColumnObject[],
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    columns: Types.ImageCarouselColumnObject[],
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.push(
       to,
       [Line.createImageCarouselTemplate(altText, columns, options)],
@@ -588,10 +559,10 @@ export default class LineClient {
   multicastRawBody(
     body: {
       to: string[];
-      messages: Message[];
+      messages: Types.Message[];
     },
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this._axios
       .post(
         '/v2/bot/message/multicast',
@@ -607,25 +578,25 @@ export default class LineClient {
 
   multicast(
     to: string[],
-    messages: Message[],
+    messages: Types.Message[],
     options?: Record<string, any>
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicastRawBody({ to, messages }, options);
   }
 
   multicastMessages(
     to: string[],
-    messages: Message[],
+    messages: Types.Message[],
     options?: Record<string, any>
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(to, messages, options);
   }
 
   multicastText(
     to: string[],
     text: string,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(to, [Line.createText(text, options)], options);
   }
 
@@ -635,8 +606,8 @@ export default class LineClient {
       originalContentUrl: string;
       previewImageUrl?: string;
     },
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(to, [Line.createImage(image, options)], options);
   }
 
@@ -646,8 +617,8 @@ export default class LineClient {
       originalContentUrl: string;
       previewImageUrl: string;
     },
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(to, [Line.createVideo(video, options)], options);
   }
 
@@ -657,16 +628,16 @@ export default class LineClient {
       originalContentUrl: string;
       duration: number;
     },
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(to, [Line.createAudio(audio, options)], options);
   }
 
   multicastLocation(
     to: string[],
-    location: Location,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    location: Types.Location,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(
       to,
       [Line.createLocation(location, options)],
@@ -676,9 +647,9 @@ export default class LineClient {
 
   multicastSticker(
     to: string[],
-    sticker: Omit<StickerMessage, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    sticker: Omit<Types.StickerMessage, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(to, [Line.createSticker(sticker, options)], options);
   }
 
@@ -690,9 +661,9 @@ export default class LineClient {
   multicastImagemap(
     to: string[],
     altText: string,
-    imagemap: Omit<ImagemapMessage, 'type' | 'altText'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    imagemap: Omit<Types.ImagemapMessage, 'type' | 'altText'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(
       to,
       [Line.createImagemap(altText, imagemap, options)],
@@ -708,9 +679,9 @@ export default class LineClient {
   multicastFlex(
     to: string[],
     altText: string,
-    flex: FlexContainer,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    flex: Types.FlexContainer,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(
       to,
       [Line.createFlex(altText, flex, options)],
@@ -726,9 +697,9 @@ export default class LineClient {
   multicastTemplate(
     to: string[],
     altText: string,
-    template: Template,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    template: Types.Template,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(
       to,
       [Line.createTemplate(altText, template, options)],
@@ -739,9 +710,9 @@ export default class LineClient {
   multicastButtonTemplate(
     to: string[],
     altText: string,
-    buttonTemplate: Omit<ButtonsTemplate, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    buttonTemplate: Omit<Types.ButtonsTemplate, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(
       to,
       [Line.createButtonTemplate(altText, buttonTemplate, options)],
@@ -752,18 +723,18 @@ export default class LineClient {
   multicastButtonsTemplate(
     to: string[],
     altText: string,
-    buttonTemplate: Omit<ButtonsTemplate, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    buttonTemplate: Omit<Types.ButtonsTemplate, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicastButtonTemplate(to, altText, buttonTemplate, options);
   }
 
   multicastConfirmTemplate(
     to: string[],
     altText: string,
-    confirmTemplate: Omit<ConfirmTemplate, 'type'>,
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    confirmTemplate: Omit<Types.ConfirmTemplate, 'type'>,
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(
       to,
       [Line.createConfirmTemplate(altText, confirmTemplate, options)],
@@ -774,7 +745,7 @@ export default class LineClient {
   multicastCarouselTemplate(
     to: string[],
     altText: string,
-    columns: ColumnObject[],
+    columns: Types.ColumnObject[],
     {
       imageAspectRatio,
       imageSize,
@@ -782,8 +753,8 @@ export default class LineClient {
     }: {
       imageAspectRatio?: 'rectangle' | 'square';
       imageSize?: 'cover' | 'contain';
-    } & MessageOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    } & Types.MessageOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(
       to,
       [
@@ -800,9 +771,9 @@ export default class LineClient {
   multicastImageCarouselTemplate(
     to: string[],
     altText: string,
-    columns: ImageCarouselColumnObject[],
-    options?: MessageOptions
-  ): Promise<MutationSuccessResponse> {
+    columns: Types.ImageCarouselColumnObject[],
+    options?: Types.MessageOptions
+  ): Promise<Types.MutationSuccessResponse> {
     return this.multicast(
       to,
       [Line.createImageCarouselTemplate(altText, columns, options)],
@@ -849,7 +820,7 @@ export default class LineClient {
   getUserProfile(
     userId: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<User> {
+  ): Promise<Types.User> {
     return this._axios
       .get(
         `/v2/bot/profile/${userId}`,
@@ -1014,7 +985,7 @@ export default class LineClient {
   leaveGroup(
     groupId: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this._axios
       .post(
         `/v2/bot/group/${groupId}/leave`,
@@ -1036,7 +1007,7 @@ export default class LineClient {
   leaveRoom(
     roomId: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     return this._axios
       .post(
         `/v2/bot/room/${roomId}/leave`,
@@ -1093,7 +1064,7 @@ export default class LineClient {
   }
 
   createRichMenu(
-    richMenu: RichMenu,
+    richMenu: Types.RichMenu,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
   ) {
     return this._axios
@@ -1337,7 +1308,7 @@ export default class LineClient {
     accessToken: customAccessToken,
   }: { accessToken?: string } = {}): Promise<{
     liffId: string;
-    view: LiffView;
+    view: Types.LiffView;
   }> {
     return this._axios
       .get(
@@ -1352,7 +1323,7 @@ export default class LineClient {
   }
 
   createLiffApp(
-    view: LiffView,
+    view: Types.LiffView,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
   ): Promise<{ liffId: string }> {
     return this._axios
@@ -1370,7 +1341,7 @@ export default class LineClient {
 
   updateLiffApp(
     liffId: string,
-    view: LiffView,
+    view: Types.LiffView,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
   ): Promise<void> {
     return this._axios
@@ -1410,9 +1381,11 @@ export default class LineClient {
   // https://developers.line.biz/en/reference/messaging-api/#get-quota
   getTargetLimitForAdditionalMessages({
     accessToken: customAccessToken,
-  }: { accessToken?: string } = {}): Promise<TargetLimitForAdditionalMessages> {
+  }: { accessToken?: string } = {}): Promise<
+    Types.TargetLimitForAdditionalMessages
+  > {
     return this._axios
-      .get<TargetLimitForAdditionalMessages>(
+      .get<Types.TargetLimitForAdditionalMessages>(
         '/v2/bot/message/quota',
         customAccessToken
           ? {
@@ -1426,9 +1399,11 @@ export default class LineClient {
   // https://developers.line.biz/en/reference/messaging-api/#get-consumption
   getNumberOfMessagesSentThisMonth({
     accessToken: customAccessToken,
-  }: { accessToken?: string } = {}): Promise<NumberOfMessagesSentThisMonth> {
+  }: { accessToken?: string } = {}): Promise<
+    Types.NumberOfMessagesSentThisMonth
+  > {
     return this._axios
-      .get<NumberOfMessagesSentThisMonth>(
+      .get<Types.NumberOfMessagesSentThisMonth>(
         '/v2/bot/message/quota/consumption',
         customAccessToken
           ? {
@@ -1443,18 +1418,21 @@ export default class LineClient {
   getNumberOfSentReplyMessages(
     date: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<NumberOfMessagesSentResponse> {
+  ): Promise<Types.NumberOfMessagesSentResponse> {
     return this._axios
-      .get<NumberOfMessagesSentResponse>('/v2/bot/message/delivery/reply', {
-        params: {
-          date,
-        },
-        ...(customAccessToken
-          ? {
-              headers: { Authorization: `Bearer ${customAccessToken}` },
-            }
-          : {}),
-      })
+      .get<Types.NumberOfMessagesSentResponse>(
+        '/v2/bot/message/delivery/reply',
+        {
+          params: {
+            date,
+          },
+          ...(customAccessToken
+            ? {
+                headers: { Authorization: `Bearer ${customAccessToken}` },
+              }
+            : {}),
+        }
+      )
       .then(res => res.data, handleError);
   }
 
@@ -1462,18 +1440,21 @@ export default class LineClient {
   getNumberOfSentPushMessages(
     date: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<NumberOfMessagesSentResponse> {
+  ): Promise<Types.NumberOfMessagesSentResponse> {
     return this._axios
-      .get<NumberOfMessagesSentResponse>('/v2/bot/message/delivery/push', {
-        params: {
-          date,
-        },
-        ...(customAccessToken
-          ? {
-              headers: { Authorization: `Bearer ${customAccessToken}` },
-            }
-          : {}),
-      })
+      .get<Types.NumberOfMessagesSentResponse>(
+        '/v2/bot/message/delivery/push',
+        {
+          params: {
+            date,
+          },
+          ...(customAccessToken
+            ? {
+                headers: { Authorization: `Bearer ${customAccessToken}` },
+              }
+            : {}),
+        }
+      )
       .then(res => res.data, handleError);
   }
 
@@ -1481,18 +1462,21 @@ export default class LineClient {
   getNumberOfSentMulticastMessages(
     date: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<NumberOfMessagesSentResponse> {
+  ): Promise<Types.NumberOfMessagesSentResponse> {
     return this._axios
-      .get<NumberOfMessagesSentResponse>('/v2/bot/message/delivery/multicast', {
-        params: {
-          date,
-        },
-        ...(customAccessToken
-          ? {
-              headers: { Authorization: `Bearer ${customAccessToken}` },
-            }
-          : {}),
-      })
+      .get<Types.NumberOfMessagesSentResponse>(
+        '/v2/bot/message/delivery/multicast',
+        {
+          params: {
+            date,
+          },
+          ...(customAccessToken
+            ? {
+                headers: { Authorization: `Bearer ${customAccessToken}` },
+              }
+            : {}),
+        }
+      )
       .then(res => res.data, handleError);
   }
 
@@ -1500,18 +1484,21 @@ export default class LineClient {
   getNumberOfSentBroadcastMessages(
     date: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<NumberOfMessagesSentResponse> {
+  ): Promise<Types.NumberOfMessagesSentResponse> {
     return this._axios
-      .get<NumberOfMessagesSentResponse>('/v2/bot/message/delivery/broadcast', {
-        params: {
-          date,
-        },
-        ...(customAccessToken
-          ? {
-              headers: { Authorization: `Bearer ${customAccessToken}` },
-            }
-          : {}),
-      })
+      .get<Types.NumberOfMessagesSentResponse>(
+        '/v2/bot/message/delivery/broadcast',
+        {
+          params: {
+            date,
+          },
+          ...(customAccessToken
+            ? {
+                headers: { Authorization: `Bearer ${customAccessToken}` },
+              }
+            : {}),
+        }
+      )
       .then(res => res.data, handleError);
   }
 
@@ -1524,9 +1511,9 @@ export default class LineClient {
   getNumberOfMessageDeliveries(
     date: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<NumberOfMessageDeliveriesResponse> {
+  ): Promise<Types.NumberOfMessageDeliveriesResponse> {
     return this._axios
-      .get<NumberOfMessageDeliveriesResponse>(
+      .get<Types.NumberOfMessageDeliveriesResponse>(
         '/v2/bot/insight/message/delivery',
         {
           params: {
@@ -1546,9 +1533,9 @@ export default class LineClient {
   getNumberOfFollowers(
     date: string,
     { accessToken: customAccessToken }: { accessToken?: string } = {}
-  ): Promise<NumberOfFollowersResponse> {
+  ): Promise<Types.NumberOfFollowersResponse> {
     return this._axios
-      .get<NumberOfFollowersResponse>('/v2/bot/insight/followers', {
+      .get<Types.NumberOfFollowersResponse>('/v2/bot/insight/followers', {
         params: {
           date,
         },
@@ -1564,9 +1551,9 @@ export default class LineClient {
   // https://developers.line.biz/en/reference/messaging-api/#get-demographic
   getFriendDemographics({
     accessToken: customAccessToken,
-  }: { accessToken?: string } = {}): Promise<FriendDemographics> {
+  }: { accessToken?: string } = {}): Promise<Types.FriendDemographics> {
     return this._axios
-      .get<FriendDemographics>(
+      .get<Types.FriendDemographics>(
         '/v2/bot/insight/demographic',
         customAccessToken
           ? {

--- a/packages/messaging-api-line/src/LinePay.ts
+++ b/packages/messaging-api-line/src/LinePay.ts
@@ -4,14 +4,7 @@ import AxiosError from 'axios-error';
 import axios, { AxiosInstance } from 'axios';
 import invariant from 'invariant';
 
-type LinePayConfig = {
-  channelId: string;
-  channelSecret: string;
-  sandbox?: boolean;
-  origin?: string;
-};
-
-type LinePayCurrency = 'USD' | 'JPY' | 'TWD' | 'THB';
+import * as Types from './LineTypes';
 
 function handleError(err: {
   message: string;
@@ -46,7 +39,7 @@ function throwWhenNotSuccess(res: {
 }
 
 export default class LinePay {
-  static connect(config: LinePayConfig): LinePay {
+  static connect(config: Types.LinePayConfig): LinePay {
     return new LinePay(config);
   }
 
@@ -57,7 +50,7 @@ export default class LinePay {
     channelSecret,
     sandbox = false,
     origin,
-  }: LinePayConfig) {
+  }: Types.LinePayConfig) {
     const linePayOrigin = sandbox
       ? 'https://sandbox-api-pay.line.me'
       : 'https://api-pay.line.me';
@@ -146,7 +139,7 @@ export default class LinePay {
   }: {
     productName: string;
     amount: number;
-    currency: LinePayCurrency;
+    currency: Types.LinePayCurrency;
     confirmUrl: string;
     orderId: string;
     productImageUrl?: string;
@@ -181,7 +174,7 @@ export default class LinePay {
       currency,
     }: {
       amount: number;
-      currency: LinePayCurrency;
+      currency: Types.LinePayCurrency;
     }
   ) {
     return this._axios
@@ -199,7 +192,7 @@ export default class LinePay {
       currency,
     }: {
       amount: number;
-      currency: LinePayCurrency;
+      currency: Types.LinePayCurrency;
     }
   ) {
     return this._axios

--- a/packages/messaging-api-line/src/LineTypes.ts
+++ b/packages/messaging-api-line/src/LineTypes.ts
@@ -1,3 +1,12 @@
+import { OnRequestFunction } from 'messaging-api-common';
+
+export type ClientConfig = {
+  accessToken: string;
+  channelSecret: string;
+  origin?: string;
+  onRequest?: OnRequestFunction;
+};
+
 export type User = {
   displayName: string;
   userId: string;
@@ -598,3 +607,13 @@ export type FriendDemographics = {
     } & PercentageAble
   >;
 };
+
+/* LINE Pay */
+export type LinePayConfig = {
+  channelId: string;
+  channelSecret: string;
+  sandbox?: boolean;
+  origin?: string;
+};
+
+export type LinePayCurrency = 'USD' | 'JPY' | 'TWD' | 'THB';

--- a/packages/messaging-api-messenger/src/Messenger.ts
+++ b/packages/messaging-api-messenger/src/Messenger.ts
@@ -2,29 +2,12 @@ import FormData from 'form-data';
 import omit from 'lodash/omit';
 import { camelcaseKeysDeep, snakecaseKeysDeep } from 'messaging-api-common';
 
-import {
-  AirlineBoardingPassAttributes,
-  AirlineCheckinAttributes,
-  AirlineItineraryAttributes,
-  AirlineUpdateAttributes,
-  Attachment,
-  FileData,
-  FileDataMediaAttachment,
-  FileDataMediaAttachmentMessage,
-  MediaAttachmentPayload,
-  MediaElement,
-  Message,
-  QuickReply,
-  ReceiptAttributes,
-  TemplateAttachmentPayload,
-  TemplateButton,
-  TemplateElement,
-} from './MessengerTypes';
+import * as Types from './MessengerTypes';
 
 function createMessage(
-  payload: Message,
-  options: { quickReplies?: QuickReply[] } = {}
-): Message {
+  payload: Types.Message,
+  options: { quickReplies?: Types.QuickReply[] } = {}
+): Types.Message {
   const message = {
     ...payload,
   };
@@ -41,17 +24,17 @@ function createMessage(
 
 function createText(
   text: string,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createMessage({ text }, options);
 }
 
 function createMessageFormData(
-  payload: FileDataMediaAttachmentMessage,
-  filedata: FileData,
-  options: { quickReplies?: QuickReply[] } = {}
+  payload: Types.FileDataMediaAttachmentMessage,
+  filedata: Types.FileData,
+  options: { quickReplies?: Types.QuickReply[] } = {}
 ): FormData {
-  const message: FileDataMediaAttachmentMessage = {
+  const message: Types.FileDataMediaAttachmentMessage = {
     ...payload,
   };
 
@@ -76,9 +59,9 @@ function createMessageFormData(
 }
 
 function createAttachment(
-  attachment: Attachment,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  attachment: Types.Attachment,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createMessage(
     {
       attachment,
@@ -88,9 +71,9 @@ function createAttachment(
 }
 
 function createAttachmentFormData(
-  attachment: FileDataMediaAttachment,
-  filedata: FileData,
-  options?: { quickReplies?: QuickReply[] }
+  attachment: Types.FileDataMediaAttachment,
+  filedata: Types.FileData,
+  options?: { quickReplies?: Types.QuickReply[] }
 ): FormData {
   return createMessageFormData(
     {
@@ -102,11 +85,11 @@ function createAttachmentFormData(
 }
 
 function createAudio(
-  audio: string | MediaAttachmentPayload,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  audio: string | Types.MediaAttachmentPayload,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   if (typeof audio === 'string') {
-    const attachment: Attachment = {
+    const attachment: Types.Attachment = {
       type: 'audio',
       payload: {
         url: audio,
@@ -115,18 +98,18 @@ function createAudio(
     return createAttachment(attachment, options);
   }
 
-  const attachment: Attachment = {
+  const attachment: Types.Attachment = {
     type: 'audio',
-    payload: audio as MediaAttachmentPayload,
+    payload: audio as Types.MediaAttachmentPayload,
   };
   return createAttachment(attachment, options);
 }
 
 function createAudioFormData(
-  audio: FileData,
-  options?: { quickReplies?: QuickReply[] }
+  audio: Types.FileData,
+  options?: { quickReplies?: Types.QuickReply[] }
 ): FormData {
-  const attachment: FileDataMediaAttachment = {
+  const attachment: Types.FileDataMediaAttachment = {
     type: 'audio',
     payload: {},
   };
@@ -135,11 +118,11 @@ function createAudioFormData(
 }
 
 function createImage(
-  image: string | MediaAttachmentPayload,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  image: string | Types.MediaAttachmentPayload,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   if (typeof image === 'string') {
-    const attachment: Attachment = {
+    const attachment: Types.Attachment = {
       type: 'image',
       payload: {
         url: image,
@@ -148,18 +131,18 @@ function createImage(
     return createAttachment(attachment, options);
   }
 
-  const attachment: Attachment = {
+  const attachment: Types.Attachment = {
     type: 'image',
-    payload: image as MediaAttachmentPayload,
+    payload: image as Types.MediaAttachmentPayload,
   };
   return createAttachment(attachment, options);
 }
 
 function createImageFormData(
-  image: FileData,
-  options?: { quickReplies?: QuickReply[] }
+  image: Types.FileData,
+  options?: { quickReplies?: Types.QuickReply[] }
 ): FormData {
-  const attachment: FileDataMediaAttachment = {
+  const attachment: Types.FileDataMediaAttachment = {
     type: 'image',
     payload: {},
   };
@@ -168,11 +151,11 @@ function createImageFormData(
 }
 
 function createVideo(
-  video: string | MediaAttachmentPayload,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  video: string | Types.MediaAttachmentPayload,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   if (typeof video === 'string') {
-    const attachment: Attachment = {
+    const attachment: Types.Attachment = {
       type: 'video',
       payload: {
         url: video,
@@ -181,18 +164,18 @@ function createVideo(
     return createAttachment(attachment, options);
   }
 
-  const attachment: Attachment = {
+  const attachment: Types.Attachment = {
     type: 'video',
-    payload: video as MediaAttachmentPayload,
+    payload: video as Types.MediaAttachmentPayload,
   };
   return createAttachment(attachment, options);
 }
 
 function createVideoFormData(
-  video: FileData,
-  options?: { quickReplies?: QuickReply[] }
+  video: Types.FileData,
+  options?: { quickReplies?: Types.QuickReply[] }
 ): FormData {
-  const attachment: FileDataMediaAttachment = {
+  const attachment: Types.FileDataMediaAttachment = {
     type: 'video',
     payload: {},
   };
@@ -201,11 +184,11 @@ function createVideoFormData(
 }
 
 function createFile(
-  file: string | MediaAttachmentPayload,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  file: string | Types.MediaAttachmentPayload,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   if (typeof file === 'string') {
-    const attachment: Attachment = {
+    const attachment: Types.Attachment = {
       type: 'file',
       payload: {
         url: file,
@@ -214,18 +197,18 @@ function createFile(
     return createAttachment(attachment, options);
   }
 
-  const attachment: Attachment = {
+  const attachment: Types.Attachment = {
     type: 'file',
-    payload: file as MediaAttachmentPayload,
+    payload: file as Types.MediaAttachmentPayload,
   };
   return createAttachment(attachment, options);
 }
 
 function createFileFormData(
-  file: FileData,
-  options?: { quickReplies?: QuickReply[] }
+  file: Types.FileData,
+  options?: { quickReplies?: Types.QuickReply[] }
 ): FormData {
-  const attachment: FileDataMediaAttachment = {
+  const attachment: Types.FileDataMediaAttachment = {
     type: 'file',
     payload: {},
   };
@@ -234,9 +217,9 @@ function createFileFormData(
 }
 
 function createTemplate(
-  payload: TemplateAttachmentPayload,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  payload: Types.TemplateAttachmentPayload,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createAttachment(
     {
       type: 'template',
@@ -248,9 +231,9 @@ function createTemplate(
 
 function createButtonTemplate(
   text: string,
-  buttons: TemplateButton[],
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  buttons: Types.TemplateButton[],
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createTemplate(
     {
       templateType: 'button',
@@ -262,12 +245,12 @@ function createButtonTemplate(
 }
 
 function createGenericTemplate(
-  elements: TemplateElement[],
+  elements: Types.TemplateElement[],
   options: {
     imageAspectRatio?: 'horizontal' | 'square';
-    quickReplies?: QuickReply[];
+    quickReplies?: Types.QuickReply[];
   } = {}
-): Message {
+): Types.Message {
   return createTemplate(
     {
       templateType: 'generic',
@@ -281,9 +264,9 @@ function createGenericTemplate(
 }
 
 function createMediaTemplate(
-  elements: MediaElement[],
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  elements: Types.MediaElement[],
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createTemplate(
     {
       templateType: 'media',
@@ -294,9 +277,9 @@ function createMediaTemplate(
 }
 
 function createReceiptTemplate(
-  attrs: ReceiptAttributes,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  attrs: Types.ReceiptAttributes,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createTemplate(
     {
       templateType: 'receipt',
@@ -307,9 +290,9 @@ function createReceiptTemplate(
 }
 
 function createAirlineBoardingPassTemplate(
-  attrs: AirlineBoardingPassAttributes,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  attrs: Types.AirlineBoardingPassAttributes,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createTemplate(
     {
       templateType: 'airline_boardingpass',
@@ -320,9 +303,9 @@ function createAirlineBoardingPassTemplate(
 }
 
 function createAirlineCheckinTemplate(
-  attrs: AirlineCheckinAttributes,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  attrs: Types.AirlineCheckinAttributes,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createTemplate(
     {
       templateType: 'airline_checkin',
@@ -333,9 +316,9 @@ function createAirlineCheckinTemplate(
 }
 
 function createAirlineItineraryTemplate(
-  attrs: AirlineItineraryAttributes,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  attrs: Types.AirlineItineraryAttributes,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createTemplate(
     {
       templateType: 'airline_itinerary',
@@ -346,9 +329,9 @@ function createAirlineItineraryTemplate(
 }
 
 function createAirlineUpdateTemplate(
-  attrs: AirlineUpdateAttributes,
-  options?: { quickReplies?: QuickReply[] }
-): Message {
+  attrs: Types.AirlineUpdateAttributes,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
   return createTemplate(
     {
       templateType: 'airline_update',

--- a/packages/messaging-api-messenger/src/MessengerBatch.ts
+++ b/packages/messaging-api-messenger/src/MessengerBatch.ts
@@ -2,32 +2,16 @@ import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
 import Messenger from './Messenger';
-import {
-  AirlineBoardingPassAttributes,
-  AirlineCheckinAttributes,
-  AirlineItineraryAttributes,
-  AirlineUpdateAttributes,
-  Attachment,
-  BatchItem,
-  BatchRequestOptions,
-  MediaAttachmentPayload,
-  MediaElement,
-  Message,
-  ReceiptAttributes,
-  Recipient,
-  SendOption,
-  SenderAction,
-  TemplateAttachmentPayload,
-  TemplateButton,
-  TemplateElement,
-  UserID,
-} from './MessengerTypes';
+import * as Types from './MessengerTypes';
 
 function omitUndefinedFields(obj = {}): object {
   return JSON.parse(JSON.stringify(obj));
 }
 
-function sendRequest(body: object, options?: BatchRequestOptions): BatchItem {
+function sendRequest(
+  body: object,
+  options?: Types.BatchRequestOptions
+): Types.BatchItem {
   return {
     method: 'POST',
     relativeUrl: 'me/messages',
@@ -37,10 +21,10 @@ function sendRequest(body: object, options?: BatchRequestOptions): BatchItem {
 }
 
 function sendMessage(
-  idOrRecipient: UserID | Recipient,
-  msg: Message,
-  options: SendOption & BatchRequestOptions = {}
-): BatchItem {
+  idOrRecipient: Types.UserID | Types.Recipient,
+  msg: Types.Message,
+  options: Types.SendOption & Types.BatchRequestOptions = {}
+): Types.BatchItem {
   const recipient =
     typeof idOrRecipient === 'string'
       ? {
@@ -68,18 +52,18 @@ function sendMessage(
 }
 
 function sendText(
-  recipient: UserID | Recipient,
+  recipient: Types.UserID | Types.Recipient,
   text: string,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(recipient, Messenger.createText(text, options), options);
 }
 
 function sendAttachment(
-  recipient: UserID | Recipient,
-  attachment: Attachment,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  attachment: Types.Attachment,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createAttachment(attachment, options),
@@ -88,42 +72,42 @@ function sendAttachment(
 }
 
 function sendAudio(
-  recipient: UserID | Recipient,
-  audio: string | MediaAttachmentPayload,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  audio: string | Types.MediaAttachmentPayload,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(recipient, Messenger.createAudio(audio, options), options);
 }
 
 function sendImage(
-  recipient: UserID | Recipient,
-  image: string | MediaAttachmentPayload,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  image: string | Types.MediaAttachmentPayload,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(recipient, Messenger.createImage(image, options), options);
 }
 
 function sendVideo(
-  recipient: UserID | Recipient,
-  video: string | MediaAttachmentPayload,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  video: string | Types.MediaAttachmentPayload,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(recipient, Messenger.createVideo(video, options), options);
 }
 
 function sendFile(
-  recipient: UserID | Recipient,
-  file: string | MediaAttachmentPayload,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  file: string | Types.MediaAttachmentPayload,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(recipient, Messenger.createFile(file, options), options);
 }
 
 function sendTemplate(
-  recipient: UserID | Recipient,
-  payload: TemplateAttachmentPayload,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  payload: Types.TemplateAttachmentPayload,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createTemplate(payload, options),
@@ -132,11 +116,11 @@ function sendTemplate(
 }
 
 function sendButtonTemplate(
-  recipient: UserID | Recipient,
+  recipient: Types.UserID | Types.Recipient,
   text: string,
-  buttons: TemplateButton[],
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  buttons: Types.TemplateButton[],
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createButtonTemplate(text, buttons, options),
@@ -145,15 +129,15 @@ function sendButtonTemplate(
 }
 
 function sendGenericTemplate(
-  recipient: UserID | Recipient,
-  elements: TemplateElement[],
+  recipient: Types.UserID | Types.Recipient,
+  elements: Types.TemplateElement[],
   {
     imageAspectRatio = 'horizontal',
     ...options
   }: {
     imageAspectRatio?: 'horizontal' | 'square';
-  } & SendOption = {}
-): BatchItem {
+  } & Types.SendOption = {}
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createGenericTemplate(elements, {
@@ -166,10 +150,10 @@ function sendGenericTemplate(
 }
 
 function sendReceiptTemplate(
-  recipient: UserID | Recipient,
-  attrs: ReceiptAttributes,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  attrs: Types.ReceiptAttributes,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createReceiptTemplate(attrs, options),
@@ -178,10 +162,10 @@ function sendReceiptTemplate(
 }
 
 function sendMediaTemplate(
-  recipient: UserID | Recipient,
-  elements: MediaElement[],
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  elements: Types.MediaElement[],
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createMediaTemplate(elements, options),
@@ -190,10 +174,10 @@ function sendMediaTemplate(
 }
 
 function sendAirlineBoardingPassTemplate(
-  recipient: UserID | Recipient,
-  attrs: AirlineBoardingPassAttributes,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  attrs: Types.AirlineBoardingPassAttributes,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createAirlineBoardingPassTemplate(attrs, options),
@@ -202,10 +186,10 @@ function sendAirlineBoardingPassTemplate(
 }
 
 function sendAirlineCheckinTemplate(
-  recipient: UserID | Recipient,
-  attrs: AirlineCheckinAttributes,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  attrs: Types.AirlineCheckinAttributes,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createAirlineCheckinTemplate(attrs, options),
@@ -214,10 +198,10 @@ function sendAirlineCheckinTemplate(
 }
 
 function sendAirlineItineraryTemplate(
-  recipient: UserID | Recipient,
-  attrs: AirlineItineraryAttributes,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  attrs: Types.AirlineItineraryAttributes,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createAirlineItineraryTemplate(attrs, options),
@@ -226,10 +210,10 @@ function sendAirlineItineraryTemplate(
 }
 
 function sendAirlineUpdateTemplate(
-  recipient: UserID | Recipient,
-  attrs: AirlineUpdateAttributes,
-  options?: SendOption & BatchRequestOptions
-): BatchItem {
+  recipient: Types.UserID | Types.Recipient,
+  attrs: Types.AirlineUpdateAttributes,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
   return sendMessage(
     recipient,
     Messenger.createAirlineUpdateTemplate(attrs, options),
@@ -239,7 +223,7 @@ function sendAirlineUpdateTemplate(
 
 function getUserProfile(
   userId: string,
-  options: { accessToken?: string } & BatchRequestOptions = {}
+  options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ) {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
@@ -253,9 +237,9 @@ function getUserProfile(
 }
 
 function sendSenderAction(
-  idOrRecipient: UserID | Recipient,
-  action: SenderAction,
-  options: SendOption & BatchRequestOptions = {}
+  idOrRecipient: Types.UserID | Types.Recipient,
+  action: Types.SenderAction,
+  options: Types.SendOption & Types.BatchRequestOptions = {}
 ) {
   const recipient =
     typeof idOrRecipient === 'string'
@@ -277,22 +261,22 @@ function sendSenderAction(
 }
 
 function typingOn(
-  idOrRecipient: UserID | Recipient,
-  options?: SendOption & BatchRequestOptions
+  idOrRecipient: Types.UserID | Types.Recipient,
+  options?: Types.SendOption & Types.BatchRequestOptions
 ) {
   return sendSenderAction(idOrRecipient, 'typing_on', options);
 }
 
 function typingOff(
-  idOrRecipient: UserID | Recipient,
-  options?: SendOption & BatchRequestOptions
+  idOrRecipient: Types.UserID | Types.Recipient,
+  options?: Types.SendOption & Types.BatchRequestOptions
 ) {
   return sendSenderAction(idOrRecipient, 'typing_off', options);
 }
 
 function markSeen(
-  idOrRecipient: UserID | Recipient,
-  options?: SendOption & BatchRequestOptions
+  idOrRecipient: Types.UserID | Types.Recipient,
+  options?: Types.SendOption & Types.BatchRequestOptions
 ) {
   return sendSenderAction(idOrRecipient, 'mark_seen', options);
 }
@@ -301,7 +285,7 @@ function passThreadControl(
   recipientId: string,
   targetAppId: number,
   metadata: string,
-  options: { accessToken?: string } & BatchRequestOptions = {}
+  options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ) {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
@@ -329,7 +313,7 @@ function passThreadControlToPageInbox(
 function takeThreadControl(
   recipientId: string,
   metadata: string,
-  options: { accessToken?: string } & BatchRequestOptions = {}
+  options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ) {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
@@ -348,7 +332,7 @@ function takeThreadControl(
 function requestThreadControl(
   recipientId: string,
   metadata: string,
-  options: { accessToken?: string } & BatchRequestOptions = {}
+  options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ) {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
@@ -366,7 +350,7 @@ function requestThreadControl(
 
 function getThreadOwner(
   recipientId: string,
-  options: { accessToken?: string } & BatchRequestOptions = {}
+  options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ) {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
@@ -381,9 +365,9 @@ function getThreadOwner(
 }
 
 function associateLabel(
-  userId: UserID,
+  userId: Types.UserID,
   labelId: number,
-  options: { accessToken?: string } & BatchRequestOptions = {}
+  options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ) {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
@@ -399,9 +383,9 @@ function associateLabel(
 }
 
 function dissociateLabel(
-  userId: UserID,
+  userId: Types.UserID,
   labelId: number,
-  options: { accessToken?: string } & BatchRequestOptions = {}
+  options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ): object {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
@@ -417,8 +401,8 @@ function dissociateLabel(
 }
 
 function getAssociatedLabels(
-  userId: UserID,
-  options: { accessToken?: string } & BatchRequestOptions = {}
+  userId: Types.UserID,
+  options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ): object {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 

--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -20,56 +20,7 @@ import {
 } from 'messaging-api-common';
 
 import Messenger from './Messenger';
-import {
-  AccessTokenOptions,
-  AirlineBoardingPassAttributes,
-  AirlineCheckinAttributes,
-  AirlineItineraryAttributes,
-  AirlineUpdateAttributes,
-  Attachment,
-  BatchItem,
-  FileData,
-  GreetingConfig,
-  IceBreaker,
-  InsightMetric,
-  InsightOptions,
-  MediaAttachmentPayload,
-  MediaElement,
-  MenuItem,
-  Message,
-  MessageTagResponse,
-  MessagingFeatureReview,
-  MessengerNLPConfig,
-  MessengerProfile,
-  MessengerSubscription,
-  MutationSuccessResponse,
-  PageInfo,
-  PersistentMenu,
-  Persona,
-  ReceiptAttributes,
-  Recipient,
-  SendMessageSuccessResponse,
-  SendOption,
-  SendSenderActionResponse,
-  SenderAction,
-  TemplateAttachmentPayload,
-  TemplateButton,
-  TemplateElement,
-  TokenInfo,
-  UploadOption,
-  User,
-  UserID,
-} from './MessengerTypes';
-
-type ClientConfig = {
-  accessToken: string;
-  appId?: string;
-  appSecret?: string;
-  version?: string;
-  origin?: string;
-  onRequest?: OnRequestFunction;
-  skipAppSecretProof?: boolean;
-};
+import * as Types from './MessengerTypes';
 
 function extractVersion(version: string): string {
   if (version.startsWith('v')) {
@@ -89,7 +40,7 @@ function handleError(err: AxiosError): void {
 
 export default class MessengerClient {
   static connect(
-    accessTokenOrConfig: string | ClientConfig,
+    accessTokenOrConfig: string | Types.ClientConfig,
     version = '4.0'
   ): MessengerClient {
     return new MessengerClient(accessTokenOrConfig, version);
@@ -107,7 +58,10 @@ export default class MessengerClient {
 
   _version: string;
 
-  constructor(accessTokenOrConfig: string | ClientConfig, version = '4.0') {
+  constructor(
+    accessTokenOrConfig: string | Types.ClientConfig,
+    version = '4.0'
+  ) {
     let origin;
     let skipAppSecretProof;
     if (accessTokenOrConfig && typeof accessTokenOrConfig === 'object') {
@@ -220,7 +174,7 @@ export default class MessengerClient {
    */
   getPageInfo({
     accessToken: customAccessToken,
-  }: AccessTokenOptions = {}): Promise<PageInfo> {
+  }: Types.AccessTokenOptions = {}): Promise<Types.PageInfo> {
     return this._axios
       .get(`/me?access_token=${customAccessToken || this._accessToken}`)
       .then(res => res.data, handleError);
@@ -233,7 +187,7 @@ export default class MessengerClient {
    */
   debugToken({
     accessToken: customAccessToken,
-  }: AccessTokenOptions = {}): Promise<TokenInfo> {
+  }: Types.AccessTokenOptions = {}): Promise<Types.TokenInfo> {
     invariant(this._appId, 'App ID is required to debug token');
     invariant(this._appSecret, 'App Secret is required to debug token');
 
@@ -306,7 +260,7 @@ export default class MessengerClient {
     accessToken: appAccessToken,
   }: {
     accessToken?: string;
-  } = {}): Promise<MessengerSubscription[]> {
+  } = {}): Promise<Types.MessengerSubscription[]> {
     const appId = this._appId;
     invariant(appId, 'App ID is required to get subscriptions');
     invariant(
@@ -330,7 +284,7 @@ export default class MessengerClient {
     accessToken: appAccessToken,
   }: {
     accessToken?: string;
-  } = {}): Promise<MessengerSubscription> {
+  } = {}): Promise<Types.MessengerSubscription> {
     const appId = this._appId;
     invariant(appId, 'App ID is required to get subscription');
     invariant(
@@ -343,7 +297,7 @@ export default class MessengerClient {
     return this.getSubscriptions({
       accessToken,
     }).then(
-      (subscriptions: MessengerSubscription[]) =>
+      (subscriptions: Types.MessengerSubscription[]) =>
         subscriptions.filter(
           subscription => subscription.object === 'page'
         )[0] || null
@@ -357,7 +311,7 @@ export default class MessengerClient {
    */
   getMessagingFeatureReview({
     accessToken: customAccessToken,
-  }: AccessTokenOptions = {}): Promise<MessagingFeatureReview[]> {
+  }: Types.AccessTokenOptions = {}): Promise<Types.MessagingFeatureReview[]> {
     return this._axios
       .get(
         `/me/messaging_feature_review?access_token=${customAccessToken ||
@@ -378,7 +332,7 @@ export default class MessengerClient {
       accessToken: customAccessToken,
       fields = ['id', 'name', 'first_name', 'last_name', 'profile_pic'],
     }: { accessToken?: string; fields?: string[] } = {}
-  ): Promise<User> {
+  ): Promise<Types.User> {
     return this._axios
       .get(
         `/${userId}?fields=${fields.join(
@@ -395,8 +349,8 @@ export default class MessengerClient {
    */
   getMessengerProfile(
     fields: string[],
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
-  ): Promise<MessengerProfile[]> {
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
+  ): Promise<Types.MessengerProfile[]> {
     return this._axios
       .get(
         `/me/messenger_profile?fields=${fields.join(
@@ -407,9 +361,9 @@ export default class MessengerClient {
   }
 
   setMessengerProfile(
-    profile: MessengerProfile,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    profile: Types.MessengerProfile,
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this._axios
       .post(
         `/me/messenger_profile?access_token=${customAccessToken ||
@@ -421,8 +375,8 @@ export default class MessengerClient {
 
   deleteMessengerProfile(
     fields: string[],
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this._axios
       .delete(
         `/me/messenger_profile?access_token=${customAccessToken ||
@@ -442,7 +396,7 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/get-started-button
    */
   getGetStarted(
-    options: AccessTokenOptions = {}
+    options: Types.AccessTokenOptions = {}
   ): Promise<{
     payload: string;
   } | null> {
@@ -457,8 +411,8 @@ export default class MessengerClient {
 
   setGetStarted(
     payload: string,
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.setMessengerProfile(
       {
         getStarted: {
@@ -470,8 +424,8 @@ export default class MessengerClient {
   }
 
   deleteGetStarted(
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.deleteMessengerProfile(['get_started'], options);
   }
 
@@ -481,15 +435,15 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/persistent-menu
    */
   getPersistentMenu(
-    options: AccessTokenOptions = {}
-  ): Promise<PersistentMenu | null> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.PersistentMenu | null> {
     return this.getMessengerProfile(['persistent_menu'], options).then(res =>
-      res[0] ? (res[0].persistentMenu as PersistentMenu) : null
+      res[0] ? (res[0].persistentMenu as Types.PersistentMenu) : null
     );
   }
 
   setPersistentMenu(
-    menuItems: MenuItem[] | PersistentMenu,
+    menuItems: Types.MenuItem[] | Types.PersistentMenu,
     {
       composerInputDisabled = false,
       ...options
@@ -497,14 +451,14 @@ export default class MessengerClient {
       composerInputDisabled?: boolean;
       accessToken?: string;
     } = {}
-  ): Promise<MutationSuccessResponse> {
+  ): Promise<Types.MutationSuccessResponse> {
     // menuItems is in type PersistentMenu
     if (
       menuItems.some((item: Record<string, any>) => item.locale === 'default')
     ) {
       return this.setMessengerProfile(
         {
-          persistentMenu: menuItems as PersistentMenu,
+          persistentMenu: menuItems as Types.PersistentMenu,
         },
         options
       );
@@ -517,7 +471,7 @@ export default class MessengerClient {
           {
             locale: 'default',
             composerInputDisabled,
-            callToActions: menuItems as MenuItem[],
+            callToActions: menuItems as Types.MenuItem[],
           },
         ],
       },
@@ -526,8 +480,8 @@ export default class MessengerClient {
   }
 
   deletePersistentMenu(
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.deleteMessengerProfile(['persistent_menu'], options);
   }
 
@@ -537,17 +491,17 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/greeting
    */
   getGreeting(
-    options: AccessTokenOptions = {}
-  ): Promise<GreetingConfig[] | null> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.GreetingConfig[] | null> {
     return this.getMessengerProfile(['greeting'], options).then(res =>
-      res[0] ? (res[0].greeting as GreetingConfig[]) : null
+      res[0] ? (res[0].greeting as Types.GreetingConfig[]) : null
     );
   }
 
   setGreeting(
-    greeting: string | GreetingConfig[],
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    greeting: string | Types.GreetingConfig[],
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     if (typeof greeting === 'string') {
       return this.setMessengerProfile(
         {
@@ -571,8 +525,8 @@ export default class MessengerClient {
   }
 
   deleteGreeting(
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.deleteMessengerProfile(['greeting'], options);
   }
 
@@ -582,17 +536,17 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/ice-breakers
    */
   getIceBreakers(
-    options: AccessTokenOptions = {}
-  ): Promise<IceBreaker[] | null> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.IceBreaker[] | null> {
     return this.getMessengerProfile(['ice_breakers'], options).then(res =>
-      res[0] ? (res[0].iceBreakers as IceBreaker[]) : null
+      res[0] ? (res[0].iceBreakers as Types.IceBreaker[]) : null
     );
   }
 
   setIceBreakers(
-    iceBreakers: IceBreaker[],
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    iceBreakers: Types.IceBreaker[],
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.setMessengerProfile(
       {
         iceBreakers,
@@ -602,8 +556,8 @@ export default class MessengerClient {
   }
 
   deleteIceBreakers(
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.deleteMessengerProfile(['ice_breakers'], options);
   }
 
@@ -613,7 +567,7 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/domain-whitelisting
    */
   getWhitelistedDomains(
-    options: AccessTokenOptions = {}
+    options: Types.AccessTokenOptions = {}
   ): Promise<string[] | null> {
     return this.getMessengerProfile(
       ['whitelisted_domains'],
@@ -623,8 +577,8 @@ export default class MessengerClient {
 
   setWhitelistedDomains(
     whitelistedDomains: string[],
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.setMessengerProfile(
       {
         whitelistedDomains,
@@ -634,8 +588,8 @@ export default class MessengerClient {
   }
 
   deleteWhitelistedDomains(
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.deleteMessengerProfile(['whitelisted_domains'], options);
   }
 
@@ -645,7 +599,7 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/account-linking-url
    */
   getAccountLinkingURL(
-    options: AccessTokenOptions = {}
+    options: Types.AccessTokenOptions = {}
   ): Promise<string | null> {
     return this.getMessengerProfile(
       ['account_linking_url'],
@@ -655,8 +609,8 @@ export default class MessengerClient {
 
   setAccountLinkingURL(
     accountLinkingUrl: string,
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.setMessengerProfile(
       {
         accountLinkingUrl,
@@ -666,8 +620,8 @@ export default class MessengerClient {
   }
 
   deleteAccountLinkingURL(
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.deleteMessengerProfile(['account_linking_url'], options);
   }
 
@@ -677,7 +631,7 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/payment-settings
    */
   getPaymentSettings(
-    options: AccessTokenOptions = {}
+    options: Types.AccessTokenOptions = {}
   ): Promise<{
     privacyUrl?: string;
     publicKey?: string;
@@ -696,8 +650,8 @@ export default class MessengerClient {
 
   setPaymentPrivacyPolicyURL(
     privacyUrl: string,
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.setMessengerProfile(
       {
         paymentSettings: {
@@ -711,8 +665,8 @@ export default class MessengerClient {
 
   setPaymentPublicKey(
     publicKey: string,
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.setMessengerProfile(
       {
         paymentSettings: {
@@ -725,8 +679,8 @@ export default class MessengerClient {
 
   setPaymentTestUsers(
     testUsers: string[],
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.setMessengerProfile(
       {
         paymentSettings: {
@@ -738,8 +692,8 @@ export default class MessengerClient {
   }
 
   deletePaymentSettings(
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.deleteMessengerProfile(['payment_settings'], options);
   }
 
@@ -749,7 +703,7 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/home-url
    */
   getHomeURL(
-    options: AccessTokenOptions = {}
+    options: Types.AccessTokenOptions = {}
   ): Promise<{
     url: string;
     webviewHeightRatio: 'tall';
@@ -779,8 +733,8 @@ export default class MessengerClient {
       webviewShareButton?: 'hide' | 'show';
       inTest: boolean;
     },
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.setMessengerProfile(
       {
         homeUrl: {
@@ -795,8 +749,8 @@ export default class MessengerClient {
   }
 
   deleteHomeURL(
-    options: AccessTokenOptions = {}
-  ): Promise<MutationSuccessResponse> {
+    options: Types.AccessTokenOptions = {}
+  ): Promise<Types.MutationSuccessResponse> {
     return this.deleteMessengerProfile(['home_url'], options);
   }
 
@@ -807,7 +761,7 @@ export default class MessengerClient {
    */
   getMessageTags({
     accessToken: customAccessToken,
-  }: AccessTokenOptions = {}): Promise<MessageTagResponse> {
+  }: Types.AccessTokenOptions = {}): Promise<Types.MessageTagResponse> {
     return this._axios
       .get(
         `/page_message_tags?access_token=${customAccessToken ||
@@ -821,7 +775,9 @@ export default class MessengerClient {
    *
    * https://developers.facebook.com/docs/messenger-platform/reference/send-api
    */
-  sendRawBody(body: Record<string, any>): Promise<SendMessageSuccessResponse> {
+  sendRawBody(
+    body: Record<string, any>
+  ): Promise<Types.SendMessageSuccessResponse> {
     const { accessToken: customAccessToken } = body;
 
     return this._axios
@@ -833,10 +789,10 @@ export default class MessengerClient {
   }
 
   sendMessage(
-    idOrRecipient: UserID | Recipient,
-    message: Message,
-    options: SendOption = {}
-  ): Promise<SendMessageSuccessResponse> {
+    idOrRecipient: Types.UserID | Types.Recipient,
+    message: Types.Message,
+    options: Types.SendOption = {}
+  ): Promise<Types.SendMessageSuccessResponse> {
     const recipient =
       typeof idOrRecipient === 'string'
         ? {
@@ -861,9 +817,9 @@ export default class MessengerClient {
   }
 
   sendMessageFormData(
-    recipient: UserID | Recipient,
+    recipient: Types.UserID | Types.Recipient,
     formdata: FormData,
-    options: SendOption = {}
+    options: Types.SendOption = {}
   ) {
     const recipientObject =
       typeof recipient === 'string'
@@ -902,10 +858,10 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/send-messages#content_types
    */
   sendAttachment(
-    recipient: UserID | Recipient,
-    attachment: Attachment,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    attachment: Types.Attachment,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createAttachment(attachment, options),
@@ -914,10 +870,10 @@ export default class MessengerClient {
   }
 
   sendText(
-    recipient: UserID | Recipient,
+    recipient: Types.UserID | Types.Recipient,
     text: string,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createText(text, options),
@@ -926,10 +882,10 @@ export default class MessengerClient {
   }
 
   sendAudio(
-    recipient: UserID | Recipient,
-    audio: string | FileData | MediaAttachmentPayload,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    audio: string | Types.FileData | Types.MediaAttachmentPayload,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     if (Buffer.isBuffer(audio) || audio instanceof fs.ReadStream) {
       const message = Messenger.createAudioFormData(audio, options);
       return this.sendMessageFormData(recipient, message, options);
@@ -940,10 +896,10 @@ export default class MessengerClient {
   }
 
   sendImage(
-    recipient: UserID | Recipient,
-    image: string | FileData | MediaAttachmentPayload,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    image: string | Types.FileData | Types.MediaAttachmentPayload,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     if (Buffer.isBuffer(image) || image instanceof fs.ReadStream) {
       const message = Messenger.createImageFormData(image, options);
       return this.sendMessageFormData(recipient, message, options);
@@ -954,10 +910,10 @@ export default class MessengerClient {
   }
 
   sendVideo(
-    recipient: UserID | Recipient,
-    video: string | FileData | MediaAttachmentPayload,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    video: string | Types.FileData | Types.MediaAttachmentPayload,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     if (Buffer.isBuffer(video) || video instanceof fs.ReadStream) {
       const message = Messenger.createVideoFormData(video, options);
       return this.sendMessageFormData(recipient, message, options);
@@ -968,10 +924,10 @@ export default class MessengerClient {
   }
 
   sendFile(
-    recipient: UserID | Recipient,
-    file: string | FileData | MediaAttachmentPayload,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    file: string | Types.FileData | Types.MediaAttachmentPayload,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     if (Buffer.isBuffer(file) || file instanceof fs.ReadStream) {
       const message = Messenger.createFileFormData(file, options);
       return this.sendMessageFormData(recipient, message, options);
@@ -987,10 +943,10 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/send-messages/templates
    */
   sendTemplate(
-    recipient: UserID | Recipient,
-    payload: TemplateAttachmentPayload,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    payload: Types.TemplateAttachmentPayload,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createTemplate(payload, options),
@@ -1000,11 +956,11 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/button
   sendButtonTemplate(
-    recipient: UserID | Recipient,
+    recipient: Types.UserID | Types.Recipient,
     text: string,
-    buttons: TemplateButton[],
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    buttons: Types.TemplateButton[],
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createButtonTemplate(text, buttons, options),
@@ -1014,12 +970,12 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic
   sendGenericTemplate(
-    recipient: UserID | Recipient,
-    elements: TemplateElement[],
+    recipient: Types.UserID | Types.Recipient,
+    elements: Types.TemplateElement[],
     options: {
       imageAspectRatio?: 'horizontal' | 'square';
-    } & SendOption = {}
-  ): Promise<SendMessageSuccessResponse> {
+    } & Types.SendOption = {}
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createGenericTemplate(elements, options),
@@ -1029,10 +985,10 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/receipt
   sendReceiptTemplate(
-    recipient: UserID | Recipient,
-    attrs: ReceiptAttributes,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    attrs: Types.ReceiptAttributes,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createReceiptTemplate(attrs, options),
@@ -1042,10 +998,10 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/media
   sendMediaTemplate(
-    recipient: UserID | Recipient,
-    elements: MediaElement[],
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    elements: Types.MediaElement[],
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createMediaTemplate(elements, options),
@@ -1055,10 +1011,10 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/airline#boarding_pass
   sendAirlineBoardingPassTemplate(
-    recipient: UserID | Recipient,
-    attrs: AirlineBoardingPassAttributes,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    attrs: Types.AirlineBoardingPassAttributes,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createAirlineBoardingPassTemplate(attrs, options),
@@ -1068,10 +1024,10 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/airline#check_in
   sendAirlineCheckinTemplate(
-    recipient: UserID | Recipient,
-    attrs: AirlineCheckinAttributes,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    attrs: Types.AirlineCheckinAttributes,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createAirlineCheckinTemplate(attrs, options),
@@ -1081,10 +1037,10 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/airline#itinerary
   sendAirlineItineraryTemplate(
-    recipient: UserID | Recipient,
-    attrs: AirlineItineraryAttributes,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    attrs: Types.AirlineItineraryAttributes,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createAirlineItineraryTemplate(attrs, options),
@@ -1094,10 +1050,10 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/airline#update
   sendAirlineUpdateTemplate(
-    recipient: UserID | Recipient,
-    attrs: AirlineUpdateAttributes,
-    options?: SendOption
-  ): Promise<SendMessageSuccessResponse> {
+    recipient: Types.UserID | Types.Recipient,
+    attrs: Types.AirlineUpdateAttributes,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
       recipient,
       Messenger.createAirlineUpdateTemplate(attrs, options),
@@ -1111,10 +1067,10 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/send-messages/sender-actions
    */
   sendSenderAction(
-    idOrRecipient: UserID | Recipient,
-    action: SenderAction,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
-  ): Promise<SendSenderActionResponse> {
+    idOrRecipient: Types.UserID | Types.Recipient,
+    action: Types.SenderAction,
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
+  ): Promise<Types.SendSenderActionResponse> {
     const recipient =
       typeof idOrRecipient === 'string'
         ? {
@@ -1129,23 +1085,23 @@ export default class MessengerClient {
   }
 
   markSeen(
-    recipient: UserID | Recipient,
+    recipient: Types.UserID | Types.Recipient,
     options: Record<string, any> = {}
-  ): Promise<SendSenderActionResponse> {
+  ): Promise<Types.SendSenderActionResponse> {
     return this.sendSenderAction(recipient, 'mark_seen', options);
   }
 
   typingOn(
-    recipient: UserID | Recipient,
+    recipient: Types.UserID | Types.Recipient,
     options: Record<string, any> = {}
-  ): Promise<SendSenderActionResponse> {
+  ): Promise<Types.SendSenderActionResponse> {
     return this.sendSenderAction(recipient, 'typing_on', options);
   }
 
   typingOff(
-    recipient: UserID | Recipient,
+    recipient: Types.UserID | Types.Recipient,
     options: Record<string, any> = {}
-  ): Promise<SendSenderActionResponse> {
+  ): Promise<Types.SendSenderActionResponse> {
     return this.sendSenderAction(recipient, 'typing_off', options);
   }
 
@@ -1155,9 +1111,9 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/graph-api/making-multiple-requests
    */
   sendBatch(
-    batch: BatchItem[],
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
-  ): Promise<SendMessageSuccessResponse[]> {
+    batch: Types.BatchItem[],
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
+  ): Promise<Types.SendMessageSuccessResponse[]> {
     invariant(
       batch.length <= 50,
       'limit the number of requests which can be in a batch to 50'
@@ -1228,7 +1184,7 @@ export default class MessengerClient {
   // FIXME: [type] return type
   createLabel(
     name: string,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .post(
@@ -1248,9 +1204,9 @@ export default class MessengerClient {
    */
   // FIXME: [type] return type
   associateLabel(
-    userId: UserID,
+    userId: Types.UserID,
     labelId: number,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .post(
@@ -1270,9 +1226,9 @@ export default class MessengerClient {
    */
   // FIXME: [type] return type
   dissociateLabel(
-    userId: UserID,
+    userId: Types.UserID,
     labelId: number,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .delete(
@@ -1292,7 +1248,7 @@ export default class MessengerClient {
    */
   // FIXME: [type] return type
   getAssociatedLabels(
-    userId: UserID,
+    userId: Types.UserID,
     options: { accessToken?: string; fields?: string[] } = {}
   ) {
     const fields = options.fields ? options.fields.join(',') : 'name';
@@ -1347,7 +1303,7 @@ export default class MessengerClient {
   // FIXME: [type] return type
   deleteLabel(
     labelId: number,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .delete(
@@ -1364,8 +1320,8 @@ export default class MessengerClient {
   // FIXME: [type] return type
   uploadAttachment(
     type: 'audio' | 'image' | 'video' | 'file',
-    attachment: string | FileData,
-    options: UploadOption = {}
+    attachment: string | Types.FileData,
+    options: Types.UploadOption = {}
   ) {
     const args = [];
 
@@ -1416,22 +1372,34 @@ export default class MessengerClient {
   }
 
   // FIXME: [type] return type
-  uploadAudio(attachment: string | FileData, options?: UploadOption) {
+  uploadAudio(
+    attachment: string | Types.FileData,
+    options?: Types.UploadOption
+  ) {
     return this.uploadAttachment('audio', attachment, options);
   }
 
   // FIXME: [type] return type
-  uploadImage(attachment: string | FileData, options?: UploadOption) {
+  uploadImage(
+    attachment: string | Types.FileData,
+    options?: Types.UploadOption
+  ) {
     return this.uploadAttachment('image', attachment, options);
   }
 
   // FIXME: [type] return type
-  uploadVideo(attachment: string | FileData, options?: UploadOption) {
+  uploadVideo(
+    attachment: string | Types.FileData,
+    options?: Types.UploadOption
+  ) {
     return this.uploadAttachment('video', attachment, options);
   }
 
   // FIXME: [type] return type
-  uploadFile(attachment: string | FileData, options?: UploadOption) {
+  uploadFile(
+    attachment: string | Types.FileData,
+    options?: Types.UploadOption
+  ) {
     return this.uploadAttachment('file', attachment, options);
   }
 
@@ -1451,7 +1419,7 @@ export default class MessengerClient {
     recipientId: string,
     targetAppId: number,
     metadata?: string,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .post(
@@ -1489,7 +1457,7 @@ export default class MessengerClient {
   takeThreadControl(
     recipientId: string,
     metadata?: string,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .post(
@@ -1512,7 +1480,7 @@ export default class MessengerClient {
   requestThreadControl(
     recipientId: string,
     metadata?: string,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .post(
@@ -1534,7 +1502,7 @@ export default class MessengerClient {
   // FIXME: [type] return type
   getSecondaryReceivers({
     accessToken: customAccessToken,
-  }: AccessTokenOptions = {}) {
+  }: Types.AccessTokenOptions = {}) {
     return this._axios
       .get(
         `/me/secondary_receivers?fields=id,name&access_token=${customAccessToken ||
@@ -1551,7 +1519,7 @@ export default class MessengerClient {
   // FIXME: [type] return type
   getThreadOwner(
     recipientId: string,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     warning(
       false,
@@ -1572,7 +1540,10 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/reference/messaging-insights-api
    */
   // FIXME: [type] return type
-  getInsights(metrics: InsightMetric[], options: InsightOptions = {}) {
+  getInsights(
+    metrics: Types.InsightMetric[],
+    options: Types.InsightOptions = {}
+  ) {
     return this._axios
       .get(
         `/me/insights/?${querystring.stringify({
@@ -1625,8 +1596,8 @@ export default class MessengerClient {
    */
   // FIXME: [type] return type
   setNLPConfigs(
-    config: MessengerNLPConfig = {},
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    config: Types.MessengerNLPConfig = {},
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .post(
@@ -1664,7 +1635,7 @@ export default class MessengerClient {
   }: {
     appId: number;
     pageId: number;
-    pageScopedUserId: UserID;
+    pageScopedUserId: Types.UserID;
     events: Record<string, any>[];
   }) {
     return this._axios
@@ -1784,8 +1755,8 @@ export default class MessengerClient {
    */
   // FIXME: [type] return type
   createPersona(
-    persona: Persona,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    persona: Types.Persona,
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .post(
@@ -1803,7 +1774,7 @@ export default class MessengerClient {
   // FIXME: [type] return type
   getPersona(
     personaId: string,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .get(
@@ -1820,7 +1791,7 @@ export default class MessengerClient {
   // FIXME: [type] return type
   getPersonas(
     cursor?: string,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ): Promise<{
     data: {
       id: string;
@@ -1840,7 +1811,7 @@ export default class MessengerClient {
 
   async getAllPersonas({
     accessToken: customAccessToken,
-  }: AccessTokenOptions = {}): Promise<Record<string, any>[]> {
+  }: Types.AccessTokenOptions = {}): Promise<Record<string, any>[]> {
     let allPersonas: Record<string, any>[] = [];
     let cursor;
 
@@ -1876,7 +1847,7 @@ export default class MessengerClient {
   // FIXME: [type] return type
   deletePersona(
     personaId: string,
-    { accessToken: customAccessToken }: AccessTokenOptions = {}
+    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
     return this._axios
       .delete(

--- a/packages/messaging-api-messenger/src/MessengerTypes.ts
+++ b/packages/messaging-api-messenger/src/MessengerTypes.ts
@@ -1,5 +1,17 @@
 import fs from 'fs';
 
+import { OnRequestFunction } from 'messaging-api-common';
+
+export type ClientConfig = {
+  accessToken: string;
+  appId?: string;
+  appSecret?: string;
+  version?: string;
+  origin?: string;
+  onRequest?: OnRequestFunction;
+  skipAppSecretProof?: boolean;
+};
+
 export type UserID = string;
 
 export type RecipientWithID = {

--- a/packages/messaging-api-slack/src/SlackOAuthClient.ts
+++ b/packages/messaging-api-slack/src/SlackOAuthClient.ts
@@ -11,7 +11,7 @@ import {
   snakecaseKeysDeep,
 } from 'messaging-api-common';
 
-import * as SlackTypes from './SlackTypes';
+import * as Types from './SlackTypes';
 
 const DEFAULT_PAYLOAD_FIELDS_TO_STRINGIFY = ['attachments', 'blocks'];
 
@@ -38,61 +38,55 @@ export default class SlackOAuthClient {
 
   chat: {
     postMessage: (
-      options: SlackTypes.PostMessageOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.PostMessageOptions
+    ) => Promise<Types.OAuthAPIResponse>;
     postEphemeral: (
-      options: SlackTypes.PostEphemeralOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.PostEphemeralOptions
+    ) => Promise<Types.OAuthAPIResponse>;
     update: (
-      options: SlackTypes.UpdateMessageOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.UpdateMessageOptions
+    ) => Promise<Types.OAuthAPIResponse>;
     delete: (
-      options: SlackTypes.DeleteMessageOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.DeleteMessageOptions
+    ) => Promise<Types.OAuthAPIResponse>;
     meMessage: (
-      options: SlackTypes.MeMessageOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.MeMessageOptions
+    ) => Promise<Types.OAuthAPIResponse>;
     getPermalink: (
-      options: SlackTypes.GetPermalinkOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.GetPermalinkOptions
+    ) => Promise<Types.OAuthAPIResponse>;
     scheduleMessage: (
-      options: SlackTypes.ScheduleMessageOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.ScheduleMessageOptions
+    ) => Promise<Types.OAuthAPIResponse>;
     deleteScheduledMessage: (
-      options: SlackTypes.DeleteScheduledMessageOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
-    unfurl: (
-      options: SlackTypes.UnfurlOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.DeleteScheduledMessageOptions
+    ) => Promise<Types.OAuthAPIResponse>;
+    unfurl: (options: Types.UnfurlOptions) => Promise<Types.OAuthAPIResponse>;
     scheduledMessages: {
       list: (
-        options: SlackTypes.GetScheduledMessagesOptions
-      ) => Promise<SlackTypes.OAuthAPIResponse>;
+        options: Types.GetScheduledMessagesOptions
+      ) => Promise<Types.OAuthAPIResponse>;
     };
   };
 
   views: {
-    open: (
-      options: SlackTypes.OpenViewOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+    open: (options: Types.OpenViewOptions) => Promise<Types.OAuthAPIResponse>;
     publish: (
-      options: SlackTypes.PublishViewOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
-    push: (
-      options: SlackTypes.PushViewOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.PublishViewOptions
+    ) => Promise<Types.OAuthAPIResponse>;
+    push: (options: Types.PushViewOptions) => Promise<Types.OAuthAPIResponse>;
     update: (
-      options: SlackTypes.UpdateViewOptions
-    ) => Promise<SlackTypes.OAuthAPIResponse>;
+      options: Types.UpdateViewOptions
+    ) => Promise<Types.OAuthAPIResponse>;
   };
 
   static connect(
-    accessTokenOrConfig: string | SlackTypes.ClientConfig
+    accessTokenOrConfig: string | Types.ClientConfig
   ): SlackOAuthClient {
     return new SlackOAuthClient(accessTokenOrConfig);
   }
 
-  constructor(accessTokenOrConfig: string | SlackTypes.ClientConfig) {
+  constructor(accessTokenOrConfig: string | Types.ClientConfig) {
     let origin;
 
     if (typeof accessTokenOrConfig === 'string') {
@@ -151,9 +145,9 @@ export default class SlackOAuthClient {
   }
 
   async callMethod(
-    method: SlackTypes.AvailableMethod,
+    method: Types.AvailableMethod,
     inputBody: Record<string, any> = {}
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+  ): Promise<Types.OAuthAPIResponse> {
     try {
       const body = {
         ...omit(inputBody, ['token', 'accessToken']),
@@ -167,7 +161,7 @@ export default class SlackOAuthClient {
 
       const data = (camelcaseKeysDeep(
         response.data
-      ) as any) as SlackTypes.OAuthAPIResponse;
+      ) as any) as Types.OAuthAPIResponse;
 
       if (!data.ok) {
         const { config, request } = response;
@@ -192,8 +186,8 @@ export default class SlackOAuthClient {
    */
   getChannelInfo(
     channelId: string,
-    options?: SlackTypes.GetInfoOptions
-  ): Promise<SlackTypes.Channel> {
+    options?: Types.GetInfoOptions
+  ): Promise<Types.Channel> {
     return this.callMethod('channels.info', {
       channel: channelId,
       ...options,
@@ -207,8 +201,8 @@ export default class SlackOAuthClient {
    */
   getConversationInfo(
     channelId: string,
-    options?: SlackTypes.GetInfoOptions
-  ): Promise<SlackTypes.Channel> {
+    options?: Types.GetInfoOptions
+  ): Promise<Types.Channel> {
     return this.callMethod('conversations.info', {
       channel: channelId,
       ...options,
@@ -222,7 +216,7 @@ export default class SlackOAuthClient {
    */
   getConversationMembers(
     channelId: string,
-    options?: SlackTypes.ConversationMembersOptions
+    options?: Types.ConversationMembersOptions
   ): Promise<{
     members: string[];
     next?: string;
@@ -238,7 +232,7 @@ export default class SlackOAuthClient {
 
   async getAllConversationMembers(
     channelId: string,
-    options?: Omit<SlackTypes.ConversationMembersOptions, 'cursor'>
+    options?: Omit<Types.ConversationMembersOptions, 'cursor'>
   ): Promise<string[]> {
     let allMembers: string[] = [];
     let continuationCursor;
@@ -269,9 +263,9 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/conversations.list
    */
   getConversationList(
-    options?: SlackTypes.ConversationListOptions
+    options?: Types.ConversationListOptions
   ): Promise<{
-    channels: SlackTypes.Channel[];
+    channels: Types.Channel[];
     next?: string;
   }> {
     return this.callMethod('conversations.list', options).then(data => ({
@@ -281,9 +275,9 @@ export default class SlackOAuthClient {
   }
 
   async getAllConversationList(
-    options?: Omit<SlackTypes.ConversationListOptions, 'cursor'>
-  ): Promise<SlackTypes.Channel[]> {
-    let allChannels: SlackTypes.Channel[] = [];
+    options?: Omit<Types.ConversationListOptions, 'cursor'>
+  ): Promise<Types.Channel[]> {
+    let allChannels: Types.Channel[] = [];
     let continuationCursor: string | undefined;
 
     do {
@@ -309,9 +303,9 @@ export default class SlackOAuthClient {
    */
   postMessage(
     channel: string,
-    inputMessage: SlackTypes.Message | string,
-    options: SlackTypes.PostMessageOptionalOptions = {}
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    inputMessage: Types.Message | string,
+    options: Types.PostMessageOptionalOptions = {}
+  ): Promise<Types.OAuthAPIResponse> {
     warning(
       false,
       '`postMessage` is deprecated. Use `chat.postMessage` instead.'
@@ -333,8 +327,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/chat.postMessage
    */
   _postMessage(
-    options: SlackTypes.PostMessageOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.PostMessageOptions
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod('chat.postMessage', stringifyPayloadFields(options));
   }
 
@@ -346,9 +340,9 @@ export default class SlackOAuthClient {
   postEphemeral(
     channel: string,
     user: string,
-    inputMessage: SlackTypes.Message | string,
-    options: SlackTypes.PostEphemeralOptionalOptions = {}
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    inputMessage: Types.Message | string,
+    options: Types.PostEphemeralOptionalOptions = {}
+  ): Promise<Types.OAuthAPIResponse> {
     warning(
       false,
       '`postEphemeral` is deprecated. Use `chat.postEphemeral` instead.'
@@ -371,8 +365,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/chat.postMessage
    */
   _postEphemeral(
-    options: SlackTypes.PostEphemeralOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.PostEphemeralOptions
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod(
       'chat.postEphemeral',
       stringifyPayloadFields(options)
@@ -385,8 +379,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/chat.update
    */
   _updateMessage(
-    options: SlackTypes.UpdateMessageOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.UpdateMessageOptions
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod('chat.update', stringifyPayloadFields(options));
   }
 
@@ -396,8 +390,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/chat.delete
    */
   _deleteMessage(
-    options: SlackTypes.DeleteMessageOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.DeleteMessageOptions
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod('chat.delete', options);
   }
 
@@ -406,9 +400,7 @@ export default class SlackOAuthClient {
    *
    * https://api.slack.com/methods/chat.meMessage
    */
-  _meMessage(
-    options: SlackTypes.MeMessageOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+  _meMessage(options: Types.MeMessageOptions): Promise<Types.OAuthAPIResponse> {
     return this.callMethod('chat.meMessage', options);
   }
 
@@ -418,8 +410,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/chat.getPermalink
    */
   _getPermalink(
-    options: SlackTypes.GetPermalinkOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.GetPermalinkOptions
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod('chat.getPermalink', options);
   }
 
@@ -429,8 +421,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/chat.scheduleMessage
    */
   _scheduleMessage(
-    options: SlackTypes.ScheduleMessageOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.ScheduleMessageOptions
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod(
       'chat.scheduleMessage',
       stringifyPayloadFields(options)
@@ -443,8 +435,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/chat.deleteScheduledMessage
    */
   _deleteScheduledMessage(
-    options: SlackTypes.DeleteScheduledMessageOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.DeleteScheduledMessageOptions
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod('chat.deleteScheduledMessage', options);
   }
 
@@ -454,8 +446,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/chat.scheduledMessages.list
    */
   _getScheduledMessages(
-    options: SlackTypes.GetScheduledMessagesOptions = {}
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.GetScheduledMessagesOptions = {}
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod('chat.scheduledMessages.list', options);
   }
 
@@ -464,9 +456,7 @@ export default class SlackOAuthClient {
    *
    * https://api.slack.com/methods/chat.unfurl
    */
-  _unfurl(
-    options: SlackTypes.UnfurlOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+  _unfurl(options: Types.UnfurlOptions): Promise<Types.OAuthAPIResponse> {
     return this.callMethod(
       'chat.unfurl',
       stringifyPayloadFields(options, ['view'])
@@ -478,9 +468,7 @@ export default class SlackOAuthClient {
    *
    * https://api.slack.com/methods/views.open
    */
-  _openView(
-    options: SlackTypes.OpenViewOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+  _openView(options: Types.OpenViewOptions): Promise<Types.OAuthAPIResponse> {
     return this.callMethod(
       'views.open',
       stringifyPayloadFields(options, ['view'])
@@ -493,8 +481,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/views.publish
    */
   _publishView(
-    options: SlackTypes.PublishViewOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.PublishViewOptions
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod(
       'views.publish',
       stringifyPayloadFields(options, ['view'])
@@ -507,8 +495,8 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/views.update
    */
   _updateView(
-    options: SlackTypes.UpdateViewOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+    options: Types.UpdateViewOptions
+  ): Promise<Types.OAuthAPIResponse> {
     return this.callMethod(
       'views.update',
       stringifyPayloadFields(options, ['view'])
@@ -520,9 +508,7 @@ export default class SlackOAuthClient {
    *
    * https://api.slack.com/methods/views.push
    */
-  _pushView(
-    options: SlackTypes.PushViewOptions
-  ): Promise<SlackTypes.OAuthAPIResponse> {
+  _pushView(options: Types.PushViewOptions): Promise<Types.OAuthAPIResponse> {
     return this.callMethod(
       'views.push',
       stringifyPayloadFields(options, ['view'])
@@ -536,8 +522,8 @@ export default class SlackOAuthClient {
    */
   getUserInfo(
     userId: string,
-    options?: SlackTypes.UserInfoOptions
-  ): Promise<SlackTypes.User> {
+    options?: Types.UserInfoOptions
+  ): Promise<Types.User> {
     return this.callMethod('users.info', { user: userId, ...options }).then(
       data => data.user
     );
@@ -549,9 +535,9 @@ export default class SlackOAuthClient {
    * https://api.slack.com/methods/users.list
    */
   getUserList(
-    options?: SlackTypes.UserListOptions
+    options?: Types.UserListOptions
   ): Promise<{
-    members: SlackTypes.User[];
+    members: Types.User[];
     next?: string;
   }> {
     return this.callMethod('users.list', options).then(data => ({
@@ -561,9 +547,9 @@ export default class SlackOAuthClient {
   }
 
   async getAllUserList(
-    options?: Omit<SlackTypes.UserListOptions, 'cursor'>
-  ): Promise<SlackTypes.User[]> {
-    let allUsers: SlackTypes.User[] = [];
+    options?: Omit<Types.UserListOptions, 'cursor'>
+  ): Promise<Types.User[]> {
+    let allUsers: Types.User[] = [];
     let continuationCursor;
 
     do {
@@ -571,7 +557,7 @@ export default class SlackOAuthClient {
         members: users,
         next,
       }: {
-        members: SlackTypes.User[];
+        members: Types.User[];
         next?: string;
         // eslint-disable-next-line no-await-in-loop
       } = await this.getUserList({

--- a/packages/messaging-api-slack/src/SlackWebhookClient.ts
+++ b/packages/messaging-api-slack/src/SlackWebhookClient.ts
@@ -5,12 +5,10 @@ import {
   snakecaseKeysDeep,
 } from 'messaging-api-common';
 
-import { Attachment, SendMessageSuccessResponse } from './SlackTypes';
-
-type URL = string;
+import * as Types from './SlackTypes';
 
 interface ClientConfig {
-  url: URL;
+  url: string;
   onRequest?: OnRequestFunction;
 }
 
@@ -19,11 +17,11 @@ export default class SlackWebhookClient {
 
   _onRequest: OnRequestFunction | undefined;
 
-  static connect(urlOrConfig: URL | ClientConfig): SlackWebhookClient {
+  static connect(urlOrConfig: string | ClientConfig): SlackWebhookClient {
     return new SlackWebhookClient(urlOrConfig);
   }
 
-  constructor(urlOrConfig: URL | ClientConfig) {
+  constructor(urlOrConfig: string | ClientConfig) {
     let url;
 
     if (urlOrConfig && typeof urlOrConfig === 'object') {
@@ -51,11 +49,13 @@ export default class SlackWebhookClient {
     return this._axios;
   }
 
-  sendRawBody(body: Record<string, any>): Promise<SendMessageSuccessResponse> {
+  sendRawBody(
+    body: Record<string, any>
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this._axios.post('', snakecaseKeysDeep(body)).then(res => res.data);
   }
 
-  sendText(text: string): Promise<SendMessageSuccessResponse> {
+  sendText(text: string): Promise<Types.SendMessageSuccessResponse> {
     return this.sendRawBody({ text });
   }
 
@@ -66,12 +66,14 @@ export default class SlackWebhookClient {
    */
 
   sendAttachments(
-    attachments: Attachment[]
-  ): Promise<SendMessageSuccessResponse> {
+    attachments: Types.Attachment[]
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendRawBody({ attachments });
   }
 
-  sendAttachment(attachment: Attachment): Promise<SendMessageSuccessResponse> {
+  sendAttachment(
+    attachment: Types.Attachment
+  ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendAttachments([attachment]);
   }
 }

--- a/packages/messaging-api-telegram/src/TelegramClient.ts
+++ b/packages/messaging-api-telegram/src/TelegramClient.ts
@@ -13,16 +13,12 @@ import {
   snakecaseKeysDeep,
 } from 'messaging-api-common';
 
-import * as Type from './TelegramTypes';
-
-type ClientConfig = {
-  accessToken: string;
-  origin?: string;
-  onRequest?: OnRequestFunction;
-};
+import * as Types from './TelegramTypes';
 
 export default class TelegramClient {
-  static connect(accessTokenOrConfig: string | ClientConfig): TelegramClient {
+  static connect(
+    accessTokenOrConfig: string | Types.ClientConfig
+  ): TelegramClient {
     return new TelegramClient(accessTokenOrConfig);
   }
 
@@ -32,7 +28,7 @@ export default class TelegramClient {
 
   _axios: AxiosInstance;
 
-  constructor(accessTokenOrConfig: string | ClientConfig) {
+  constructor(accessTokenOrConfig: string | Types.ClientConfig) {
     let origin;
     if (accessTokenOrConfig && typeof accessTokenOrConfig === 'object') {
       const config = accessTokenOrConfig;
@@ -112,7 +108,7 @@ export default class TelegramClient {
    *
    * - https://core.telegram.org/bots/api#getupdates
    */
-  getUpdates(options?: Type.GetUpdatesOption): Promise<Type.Update[]> {
+  getUpdates(options?: Types.GetUpdatesOption): Promise<Types.Update[]> {
     return this._request('/getUpdates', {
       ...options,
     });
@@ -123,7 +119,7 @@ export default class TelegramClient {
    *
    * - https://core.telegram.org/bots/api#getwebhookinfo
    */
-  getWebhookInfo(): Promise<Type.WebhookInfo> {
+  getWebhookInfo(): Promise<Types.WebhookInfo> {
     return this._request('/getWebhookInfo');
   }
 
@@ -142,7 +138,7 @@ export default class TelegramClient {
    */
   setWebhook(
     url: string,
-    options: Type.SetWebhookOption = {}
+    options: Types.SetWebhookOption = {}
   ): Promise<boolean> {
     const optionsWithoutCertificate = this._optionWithoutKeys(options, [
       'certificate',
@@ -165,7 +161,7 @@ export default class TelegramClient {
   /**
    * - https://core.telegram.org/bots/api#getme
    */
-  getMe(): Promise<Type.User> {
+  getMe(): Promise<Types.User> {
     return this._request('/getMe');
   }
 
@@ -180,8 +176,8 @@ export default class TelegramClient {
   sendMessage(
     chatId: string | number,
     text: string,
-    options?: Type.SendMessageOption
-  ): Promise<Type.Message> {
+    options?: Types.SendMessageOption
+  ): Promise<Types.Message> {
     return this._request('/sendMessage', {
       chatId,
       text,
@@ -202,8 +198,8 @@ export default class TelegramClient {
     chatId: string | number,
     fromChatId: string | number,
     messageId: number,
-    options?: Type.ForwardMessageOption
-  ): Promise<Type.Message> {
+    options?: Types.ForwardMessageOption
+  ): Promise<Types.Message> {
     return this._request('/forwardMessage', {
       chatId,
       fromChatId,
@@ -224,8 +220,8 @@ export default class TelegramClient {
   sendPhoto(
     chatId: string | number,
     photo: string,
-    options: Type.SendPhotoOption = {}
-  ): Promise<Type.Message> {
+    options: Types.SendPhotoOption = {}
+  ): Promise<Types.Message> {
     return this._request('/sendPhoto', {
       chatId,
       photo,
@@ -247,8 +243,8 @@ export default class TelegramClient {
   sendAudio(
     chatId: string | number,
     audio: string,
-    options: Type.SendAudioOption = {}
-  ): Promise<Type.Message> {
+    options: Types.SendAudioOption = {}
+  ): Promise<Types.Message> {
     const optionsWithoutThumb = pick(options, [
       'caption',
       'parse_mode',
@@ -282,8 +278,8 @@ export default class TelegramClient {
   sendDocument(
     chatId: string | number,
     document: string,
-    options: Type.SendDocumentOption = {}
-  ): Promise<Type.Message> {
+    options: Types.SendDocumentOption = {}
+  ): Promise<Types.Message> {
     const optionsWithoutThumb = this._optionWithoutKeys(options, ['thumb']);
 
     return this._request('/sendDocument', {
@@ -305,8 +301,8 @@ export default class TelegramClient {
   sendVideo(
     chatId: string | number,
     video: string,
-    options: Type.SendVideoOption = {}
-  ): Promise<Type.Message> {
+    options: Types.SendVideoOption = {}
+  ): Promise<Types.Message> {
     const optionsWithoutThumb = this._optionWithoutKeys(options, ['thumb']);
 
     return this._request('/sendVideo', {
@@ -328,8 +324,8 @@ export default class TelegramClient {
   sendAnimation(
     chatId: string | number,
     animation: string,
-    options: Type.SendAnimationOption = {}
-  ): Promise<Type.Message> {
+    options: Types.SendAnimationOption = {}
+  ): Promise<Types.Message> {
     const optionsWithoutThumb = this._optionWithoutKeys(options, ['thumb']);
 
     return this._request('/sendAnimation', {
@@ -351,8 +347,8 @@ export default class TelegramClient {
   sendVoice(
     chatId: string | number,
     voice: string,
-    options: Type.SendVoiceOption = {}
-  ): Promise<Type.Message> {
+    options: Types.SendVoiceOption = {}
+  ): Promise<Types.Message> {
     return this._request('/sendVoice', {
       chatId,
       voice,
@@ -372,8 +368,8 @@ export default class TelegramClient {
   sendVideoNote(
     chatId: string | number,
     videoNote: string,
-    options: Type.SendVideoNoteOption = {}
-  ): Promise<Type.Message> {
+    options: Types.SendVideoNoteOption = {}
+  ): Promise<Types.Message> {
     const optionsWithoutThumb = this._optionWithoutKeys(options, ['thumb']);
 
     return this._request('/sendVideoNote', {
@@ -394,9 +390,9 @@ export default class TelegramClient {
    */
   sendMediaGroup(
     chatId: string | number,
-    media: (Type.InputMediaPhoto | Type.InputMediaVideo)[],
-    options?: Type.SendMediaGroupOption
-  ): Promise<Type.Message[]> {
+    media: (Types.InputMediaPhoto | Types.InputMediaVideo)[],
+    options?: Types.SendMediaGroupOption
+  ): Promise<Types.Message[]> {
     const mediaWithoutThumb = media.map(m =>
       this._optionWithoutKeys(m, ['thumb'])
     );
@@ -420,8 +416,8 @@ export default class TelegramClient {
   sendLocation(
     chatId: string | number,
     { latitude, longitude }: { latitude: number; longitude: number },
-    options?: Type.SendLocationOption
-  ): Promise<Type.Message> {
+    options?: Types.SendLocationOption
+  ): Promise<Types.Message> {
     return this._request('/sendLocation', {
       chatId,
       latitude,
@@ -444,8 +440,8 @@ export default class TelegramClient {
    */
   editMessageLiveLocation(
     { latitude, longitude }: { latitude: number; longitude: number },
-    options: Type.EditMessageLiveLocationOption
-  ): Promise<Type.Message | boolean> {
+    options: Types.EditMessageLiveLocationOption
+  ): Promise<Types.Message | boolean> {
     return this._request('/editMessageLiveLocation', {
       latitude,
       longitude,
@@ -464,8 +460,8 @@ export default class TelegramClient {
    * - https://core.telegram.org/bots/api#stopmessagelivelocation
    */
   stopMessageLiveLocation(
-    options: Type.StopMessageLiveLocationOption
-  ): Promise<Type.Message | boolean> {
+    options: Types.StopMessageLiveLocationOption
+  ): Promise<Types.Message | boolean> {
     return this._request('/stopMessageLiveLocation', {
       ...options,
     });
@@ -485,9 +481,9 @@ export default class TelegramClient {
    */
   sendVenue(
     chatId: string | number,
-    venue: Type.Venue,
-    options?: Type.SendVenueOption
-  ): Promise<Type.Message> {
+    venue: Types.Venue,
+    options?: Types.SendVenueOption
+  ): Promise<Types.Message> {
     return this._request('/sendVenue', {
       chatId,
       ...venue.location,
@@ -508,9 +504,9 @@ export default class TelegramClient {
    */
   sendContact(
     chatId: string | number,
-    requiredOptions: Type.SendContactRequiredOption,
-    options?: Type.SendContactOption
-  ): Promise<Type.Message> {
+    requiredOptions: Types.SendContactRequiredOption,
+    options?: Types.SendContactOption
+  ): Promise<Types.Message> {
     return this._request('/sendContact', {
       chatId,
       ...requiredOptions,
@@ -532,8 +528,8 @@ export default class TelegramClient {
     chatId: string | number,
     question: string,
     options: string[],
-    otherOptions?: Type.SendPollOption
-  ): Promise<Type.Message> {
+    otherOptions?: Types.SendPollOption
+  ): Promise<Types.Message> {
     return this._request('/sendPoll', {
       chatId,
       question,
@@ -548,13 +544,13 @@ export default class TelegramClient {
    * Example: The ImageBot needs some time to process a request and upload the image. Instead of sending a text message along the lines of “Retrieving image, please wait…”, the bot may use sendChatAction with action = upload_photo. The user will see a “sending photo” status for the bot.
    *
    * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-   * @param action Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_audio or upload_audio for audio files, upload_document for general files, find_location for location data, record_video_note or upload_video_note for video notes.
+   * @param action Types of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_audio or upload_audio for audio files, upload_document for general files, find_location for location data, record_video_note or upload_video_note for video notes.
    *
    * - https://core.telegram.org/bots/api#sendchataction
    */
   sendChatAction(
     chatId: string | number,
-    action: Type.ChatAction
+    action: Types.ChatAction
   ): Promise<boolean> {
     return this._request('/sendChatAction', {
       chatId,
@@ -572,8 +568,8 @@ export default class TelegramClient {
    */
   getUserProfilePhotos(
     userId: number,
-    options?: Type.GetUserProfilePhotosOption
-  ): Promise<Type.UserProfilePhotos> {
+    options?: Types.GetUserProfilePhotosOption
+  ): Promise<Types.UserProfilePhotos> {
     return this._request('/getUserProfilePhotos', {
       userId,
       ...options,
@@ -587,7 +583,7 @@ export default class TelegramClient {
    *
    * - https://core.telegram.org/bots/api#getfile
    */
-  getFile(fileId: string): Promise<Type.File> {
+  getFile(fileId: string): Promise<Types.File> {
     return this._request('/getFile', {
       fileId,
     });
@@ -617,7 +613,7 @@ export default class TelegramClient {
   kickChatMember(
     chatId: string | number,
     userId: number,
-    options?: Type.KickChatMemberOption
+    options?: Types.KickChatMemberOption
   ): Promise<boolean> {
     return this._request('/kickChatMember', {
       chatId,
@@ -654,8 +650,8 @@ export default class TelegramClient {
   restrictChatMember(
     chatId: string | number,
     userId: number,
-    permissions: Type.ChatPermissions,
-    options?: Type.RestrictChatMemberOption
+    permissions: Types.ChatPermissions,
+    options?: Types.RestrictChatMemberOption
   ): Promise<boolean> {
     return this._request('/restrictChatMember', {
       chatId,
@@ -677,7 +673,7 @@ export default class TelegramClient {
   promoteChatMember(
     chatId: string | number,
     userId: number,
-    options?: Type.PromoteChatMemberOption
+    options?: Types.PromoteChatMemberOption
   ): Promise<boolean> {
     return this._request('/promoteChatMember', {
       chatId,
@@ -696,7 +692,7 @@ export default class TelegramClient {
    */
   setChatPermissions(
     chatId: string | number,
-    permissions: Type.ChatPermissions
+    permissions: Types.ChatPermissions
   ): Promise<boolean> {
     return this._request('/setChatPermissions', {
       chatId,
@@ -793,7 +789,7 @@ export default class TelegramClient {
   pinChatMessage(
     chatId: string | number,
     messageId: number,
-    options?: Type.PinChatMessageOption
+    options?: Types.PinChatMessageOption
   ): Promise<boolean> {
     return this._request('/pinChatMessage', {
       chatId,
@@ -835,7 +831,7 @@ export default class TelegramClient {
    *
    * - https://core.telegram.org/bots/api#getchat
    */
-  getChat(chatId: string | number): Promise<Type.Chat> {
+  getChat(chatId: string | number): Promise<Types.Chat> {
     return this._request('/getChat', {
       chatId,
     });
@@ -848,7 +844,7 @@ export default class TelegramClient {
    *
    * - https://core.telegram.org/bots/api#getchatmemberscount
    */
-  getChatAdministrators(chatId: string | number): Promise<Type.ChatMember[]> {
+  getChatAdministrators(chatId: string | number): Promise<Types.ChatMember[]> {
     return this._request('/getChatAdministrators', {
       chatId,
     });
@@ -878,7 +874,7 @@ export default class TelegramClient {
   getChatMember(
     chatId: string | number,
     userId: number
-  ): Promise<Type.ChatMember> {
+  ): Promise<Types.ChatMember> {
     return this._request('/getChatMember', {
       chatId,
       userId,
@@ -928,7 +924,7 @@ export default class TelegramClient {
    */
   answerCallbackQuery(
     callbackQueryId: string,
-    options: Type.AnswerCallbackQueryOption
+    options: Types.AnswerCallbackQueryOption
   ): Promise<boolean> {
     return this._request('/answerCallbackQuery', {
       callbackQueryId,
@@ -946,8 +942,8 @@ export default class TelegramClient {
    */
   editMessageText(
     text: string,
-    options?: Type.EditMessageTextOption
-  ): Promise<Type.Message | boolean> {
+    options?: Types.EditMessageTextOption
+  ): Promise<Types.Message | boolean> {
     return this._request('/editMessageText', {
       text,
       ...options,
@@ -964,8 +960,8 @@ export default class TelegramClient {
    */
   editMessageCaption(
     caption: string,
-    options?: Type.EditMessageCaptionOption
-  ): Promise<Type.Message | boolean> {
+    options?: Types.EditMessageCaptionOption
+  ): Promise<Types.Message | boolean> {
     return this._request('/editMessageCaption', {
       caption,
       ...options,
@@ -981,9 +977,9 @@ export default class TelegramClient {
    * - https://core.telegram.org/bots/api#editmessagemedia
    */
   editMessageMedia(
-    media: Type.InputMedia,
-    options: Type.EditMessageMediaOption
-  ): Promise<Type.Message | boolean> {
+    media: Types.InputMedia,
+    options: Types.EditMessageMediaOption
+  ): Promise<Types.Message | boolean> {
     return this._request('/editMessageMedia', {
       media,
       ...options,
@@ -999,9 +995,9 @@ export default class TelegramClient {
    * - https://core.telegram.org/bots/api#editmessagereplymarkup
    */
   editMessageReplyMarkup(
-    replyMarkup: Type.InlineKeyboardMarkup,
-    options?: Type.EditMessageReplyMarkupOption
-  ): Promise<Type.Message | boolean> {
+    replyMarkup: Types.InlineKeyboardMarkup,
+    options?: Types.EditMessageReplyMarkupOption
+  ): Promise<Types.Message | boolean> {
     return this._request('/editMessageReplyMarkup', {
       replyMarkup,
       ...options,
@@ -1020,8 +1016,8 @@ export default class TelegramClient {
   stopPoll(
     chatId: string | number,
     messageId: number,
-    options?: Type.StopPollOption
-  ): Promise<Type.Poll> {
+    options?: Types.StopPollOption
+  ): Promise<Types.Poll> {
     return this._request('/stopPoll', {
       chatId,
       messageId,
@@ -1060,8 +1056,8 @@ export default class TelegramClient {
   sendSticker(
     chatId: string | number,
     sticker: string,
-    options?: Type.SendStickerOption
-  ): Promise<Type.Message> {
+    options?: Types.SendStickerOption
+  ): Promise<Types.Message> {
     return this._request('/sendSticker', {
       chatId,
       sticker,
@@ -1076,7 +1072,7 @@ export default class TelegramClient {
    *
    * - https://core.telegram.org/bots/api#getstickerset
    */
-  getStickerSet(name: string): Promise<Type.StickerSet> {
+  getStickerSet(name: string): Promise<Types.StickerSet> {
     return this._request('/getStickerSet', { name });
   }
 
@@ -1101,7 +1097,7 @@ export default class TelegramClient {
     title: string,
     pngSticker: string,
     emojis: string,
-    options?: Type.CreateNewStickerSetOption
+    options?: Types.CreateNewStickerSetOption
   ): Promise<boolean> {
     return this._request('/createNewStickerSet', {
       userId,
@@ -1129,7 +1125,7 @@ export default class TelegramClient {
     name: string,
     pngSticker: string,
     emojis: string,
-    options?: Type.AddStickerToSetOption
+    options?: Types.AddStickerToSetOption
   ): Promise<boolean> {
     return this._request('/addStickerToSet', {
       userId,
@@ -1177,8 +1173,8 @@ export default class TelegramClient {
    */
   answerInlineQuery(
     inlineQueryId: string,
-    results: Type.InlineQueryResult[],
-    options?: Type.AnswerInlineQueryOption
+    results: Types.InlineQueryResult[],
+    options?: Types.AnswerInlineQueryOption
   ): Promise<boolean> {
     return this._request('/answerInlineQuery', {
       inlineQueryId,
@@ -1204,9 +1200,9 @@ export default class TelegramClient {
    */
   sendInvoice(
     chatId: number,
-    product: Type.Product,
-    options?: Type.SendInvoiceOption
-  ): Promise<Type.Message> {
+    product: Types.Product,
+    options?: Types.SendInvoiceOption
+  ): Promise<Types.Message> {
     return this._request('/sendInvoice', {
       chatId,
       ...product,
@@ -1226,7 +1222,7 @@ export default class TelegramClient {
   answerShippingQuery(
     shippingQueryId: string,
     ok: boolean,
-    options?: Type.AnswerShippingQueryOption
+    options?: Types.AnswerShippingQueryOption
   ): Promise<boolean> {
     return this._request('/answerShippingQuery', {
       shippingQueryId,
@@ -1247,7 +1243,7 @@ export default class TelegramClient {
   answerPreCheckoutQuery(
     preCheckoutQueryId: string,
     ok: boolean,
-    options?: Type.AnswerPreCheckoutQueryOption
+    options?: Types.AnswerPreCheckoutQueryOption
   ): Promise<boolean> {
     return this._request('/answerPreCheckoutQuery', {
       preCheckoutQueryId,
@@ -1273,8 +1269,8 @@ export default class TelegramClient {
   sendGame(
     chatId: number,
     gameShortName: string,
-    options?: Type.SendGameOption
-  ): Promise<Type.Message> {
+    options?: Types.SendGameOption
+  ): Promise<Types.Message> {
     return this._request('/sendGame', {
       chatId,
       gameShortName,
@@ -1294,8 +1290,8 @@ export default class TelegramClient {
   setGameScore(
     userId: number,
     score: number,
-    options?: Type.SetGameScoreOption
-  ): Promise<Type.Message | boolean> {
+    options?: Types.SetGameScoreOption
+  ): Promise<Types.Message | boolean> {
     return this._request('/setGameScore', {
       userId,
       score,
@@ -1315,8 +1311,8 @@ export default class TelegramClient {
    */
   getGameHighScores(
     userId: number,
-    options?: Type.GetGameHighScoresOption
-  ): Promise<Type.GameHighScore[]> {
+    options?: Types.GetGameHighScoresOption
+  ): Promise<Types.GameHighScore[]> {
     return this._request('/getGameHighScores', {
       userId,
       ...options,

--- a/packages/messaging-api-telegram/src/TelegramTypes.ts
+++ b/packages/messaging-api-telegram/src/TelegramTypes.ts
@@ -1,3 +1,11 @@
+import { OnRequestFunction } from 'messaging-api-common';
+
+export type ClientConfig = {
+  accessToken: string;
+  origin?: string;
+  onRequest?: OnRequestFunction;
+};
+
 export type Update = {
   updateId: string;
   message?: Message;

--- a/packages/messaging-api-viber/src/ViberClient.ts
+++ b/packages/messaging-api-viber/src/ViberClient.ts
@@ -12,33 +12,9 @@ import {
   snakecaseKeysDeep,
 } from 'messaging-api-common';
 
-import {
-  AccountInfo,
-  BroadcastResponseData,
-  Contact,
-  EventType,
-  File,
-  Location,
-  Message,
-  MessageOptions,
-  Picture,
-  ResponseData,
-  RichMedia,
-  Sender,
-  SucceededResponseData,
-  UserDetails,
-  UserOnlineStatus,
-  Video,
-} from './ViberTypes';
+import * as Types from './ViberTypes';
 
-type ClientConfig = {
-  accessToken: string;
-  sender: Sender;
-  origin?: string;
-  onRequest?: OnRequestFunction;
-};
-
-function transformMessageCase(message: Message): any {
+function transformMessageCase(message: Types.Message): any {
   const { keyboard, richMedia, ...others } = message as any;
 
   return {
@@ -57,21 +33,24 @@ function transformMessageCase(message: Message): any {
  */
 export default class ViberClient {
   static connect(
-    accessTokenOrConfig: string | ClientConfig,
-    sender?: Sender
+    accessTokenOrConfig: string | Types.ClientConfig,
+    sender?: Types.Sender
   ): ViberClient {
     return new ViberClient(accessTokenOrConfig, sender);
   }
 
   _token: string;
 
-  _sender: Sender;
+  _sender: Types.Sender;
 
   _onRequest: OnRequestFunction | undefined;
 
   _axios: AxiosInstance;
 
-  constructor(accessTokenOrConfig: string | ClientConfig, sender?: Sender) {
+  constructor(
+    accessTokenOrConfig: string | Types.ClientConfig,
+    sender?: Types.Sender
+  ) {
     let origin;
     if (accessTokenOrConfig && typeof accessTokenOrConfig === 'object') {
       const config = accessTokenOrConfig;
@@ -82,7 +61,7 @@ export default class ViberClient {
       origin = config.origin;
     } else {
       this._token = accessTokenOrConfig;
-      this._sender = sender as Sender;
+      this._sender = sender as Types.Sender;
       this._onRequest = onRequest;
     }
 
@@ -110,7 +89,7 @@ export default class ViberClient {
   async _callAPI<R extends object>(
     path: string,
     body: Record<string, any> = {}
-  ): Promise<SucceededResponseData<R> | never> {
+  ): Promise<Types.SucceededResponseData<R> | never> {
     try {
       const response = await this._axios.post(
         path,
@@ -122,7 +101,9 @@ export default class ViberClient {
 
       const { config, request } = response;
 
-      const data = (camelcaseKeysDeep(response.data) as any) as ResponseData<R>;
+      const data = (camelcaseKeysDeep(
+        response.data
+      ) as any) as Types.ResponseData<R>;
 
       if (data.status !== 0) {
         throw new AxiosError(`Viber API - ${data.statusMessage}`, {
@@ -152,15 +133,15 @@ export default class ViberClient {
   setWebhook(
     url: string,
     optionsOrEventTypes:
-      | EventType[]
+      | Types.EventType[]
       | {
-          eventTypes?: EventType[];
+          eventTypes?: Types.EventType[];
           sendName?: boolean;
           sendPhoto?: boolean;
         } = {}
   ): Promise<
-    | SucceededResponseData<{
-        eventTypes: EventType[];
+    | Types.SucceededResponseData<{
+        eventTypes: Types.EventType[];
       }>
     | never
   > {
@@ -169,7 +150,7 @@ export default class ViberClient {
       : optionsOrEventTypes;
 
     return this._callAPI<{
-      eventTypes: EventType[];
+      eventTypes: Types.EventType[];
     }>('/set_webhook', {
       url,
       ...options,
@@ -182,8 +163,8 @@ export default class ViberClient {
    * https://developers.viber.com/docs/api/rest-bot-api/#removing-your-webhook
    */
   removeWebhook(): Promise<
-    | SucceededResponseData<{
-        eventTypes: EventType[];
+    | Types.SucceededResponseData<{
+        eventTypes: Types.EventType[];
       }>
     | never
   > {
@@ -197,8 +178,8 @@ export default class ViberClient {
    */
   sendMessage(
     receiver: string,
-    message: Message
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    message: Types.Message
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this._callAPI('/send_message', {
       receiver,
       sender: this._sender,
@@ -212,8 +193,8 @@ export default class ViberClient {
   sendText(
     receiver: string,
     text: string,
-    options?: MessageOptions
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    options?: Types.MessageOptions
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this.sendMessage(receiver, {
       type: 'text',
       text,
@@ -226,9 +207,9 @@ export default class ViberClient {
    */
   sendPicture(
     receiver: string,
-    { text, media, thumbnail }: Picture,
-    options?: MessageOptions
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    { text, media, thumbnail }: Types.Picture,
+    options?: Types.MessageOptions
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this.sendMessage(receiver, {
       type: 'picture',
       text,
@@ -243,9 +224,9 @@ export default class ViberClient {
    */
   sendVideo(
     receiver: string,
-    { media, size, thumbnail, duration }: Video,
-    options?: MessageOptions
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    { media, size, thumbnail, duration }: Types.Video,
+    options?: Types.MessageOptions
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this.sendMessage(receiver, {
       type: 'video',
       media,
@@ -261,9 +242,9 @@ export default class ViberClient {
    */
   sendFile(
     receiver: string,
-    file: File,
-    options?: MessageOptions
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    file: Types.File,
+    options?: Types.MessageOptions
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this.sendMessage(receiver, {
       type: 'file',
       ...file,
@@ -276,9 +257,9 @@ export default class ViberClient {
    */
   sendContact(
     receiver: string,
-    contact: Contact,
-    options?: MessageOptions
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    contact: Types.Contact,
+    options?: Types.MessageOptions
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this.sendMessage(receiver, {
       type: 'contact',
       contact,
@@ -291,9 +272,9 @@ export default class ViberClient {
    */
   sendLocation(
     receiver: string,
-    { lat, lon }: Location,
-    options?: MessageOptions
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    { lat, lon }: Types.Location,
+    options?: Types.MessageOptions
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this.sendMessage(receiver, {
       type: 'location',
       location: { lat, lon },
@@ -307,8 +288,8 @@ export default class ViberClient {
   sendURL(
     receiver: string,
     url: string,
-    options?: MessageOptions
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    options?: Types.MessageOptions
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this.sendMessage(receiver, {
       type: 'url',
       media: url,
@@ -322,8 +303,8 @@ export default class ViberClient {
   sendSticker(
     receiver: string,
     stickerId: number,
-    options?: MessageOptions
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    options?: Types.MessageOptions
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this.sendMessage(receiver, {
       type: 'sticker',
       stickerId,
@@ -336,9 +317,9 @@ export default class ViberClient {
    */
   sendCarouselContent(
     receiver: string,
-    richMedia: RichMedia,
-    options?: MessageOptions
-  ): Promise<SucceededResponseData<{ messageToken: number }> | never> {
+    richMedia: Types.RichMedia,
+    options?: Types.MessageOptions
+  ): Promise<Types.SucceededResponseData<{ messageToken: number }> | never> {
     return this.sendMessage(receiver, {
       type: 'rich_media',
       minApiVersion: 2,
@@ -354,8 +335,8 @@ export default class ViberClient {
    */
   broadcastMessage(
     broadcastList: string[],
-    message: Message
-  ): Promise<BroadcastResponseData | never> {
+    message: Types.Message
+  ): Promise<Types.BroadcastResponseData | never> {
     return this._callAPI('/broadcast_message', {
       broadcastList,
       sender: this._sender,
@@ -369,8 +350,8 @@ export default class ViberClient {
   broadcastText(
     broadcastList: string[],
     text: string,
-    options?: MessageOptions
-  ): Promise<BroadcastResponseData | never> {
+    options?: Types.MessageOptions
+  ): Promise<Types.BroadcastResponseData | never> {
     return this.broadcastMessage(broadcastList, {
       type: 'text',
       text,
@@ -383,9 +364,9 @@ export default class ViberClient {
    */
   broadcastPicture(
     broadcastList: string[],
-    { text, media, thumbnail }: Picture,
-    options?: MessageOptions
-  ): Promise<BroadcastResponseData | never> {
+    { text, media, thumbnail }: Types.Picture,
+    options?: Types.MessageOptions
+  ): Promise<Types.BroadcastResponseData | never> {
     return this.broadcastMessage(broadcastList, {
       type: 'picture',
       text,
@@ -400,9 +381,9 @@ export default class ViberClient {
    */
   broadcastVideo(
     broadcastList: string[],
-    { media, size, thumbnail, duration }: Video,
-    options?: MessageOptions
-  ): Promise<BroadcastResponseData | never> {
+    { media, size, thumbnail, duration }: Types.Video,
+    options?: Types.MessageOptions
+  ): Promise<Types.BroadcastResponseData | never> {
     return this.broadcastMessage(broadcastList, {
       type: 'video',
       media,
@@ -418,9 +399,9 @@ export default class ViberClient {
    */
   broadcastFile(
     broadcastList: string[],
-    file: File,
-    options?: MessageOptions
-  ): Promise<BroadcastResponseData | never> {
+    file: Types.File,
+    options?: Types.MessageOptions
+  ): Promise<Types.BroadcastResponseData | never> {
     return this.broadcastMessage(broadcastList, {
       type: 'file',
       ...file,
@@ -433,9 +414,9 @@ export default class ViberClient {
    */
   broadcastContact(
     broadcastList: string[],
-    contact: Contact,
-    options?: MessageOptions
-  ): Promise<BroadcastResponseData | never> {
+    contact: Types.Contact,
+    options?: Types.MessageOptions
+  ): Promise<Types.BroadcastResponseData | never> {
     return this.broadcastMessage(broadcastList, {
       type: 'contact',
       contact,
@@ -448,9 +429,9 @@ export default class ViberClient {
    */
   broadcastLocation(
     broadcastList: string[],
-    { lat, lon }: Location,
-    options?: MessageOptions
-  ): Promise<BroadcastResponseData | never> {
+    { lat, lon }: Types.Location,
+    options?: Types.MessageOptions
+  ): Promise<Types.BroadcastResponseData | never> {
     return this.broadcastMessage(broadcastList, {
       type: 'location',
       location: { lat, lon },
@@ -464,8 +445,8 @@ export default class ViberClient {
   broadcastURL(
     broadcastList: string[],
     url: string,
-    options?: MessageOptions
-  ): Promise<BroadcastResponseData | never> {
+    options?: Types.MessageOptions
+  ): Promise<Types.BroadcastResponseData | never> {
     return this.broadcastMessage(broadcastList, {
       type: 'url',
       media: url,
@@ -479,8 +460,8 @@ export default class ViberClient {
   broadcastSticker(
     broadcastList: string[],
     stickerId: number,
-    options?: MessageOptions
-  ): Promise<BroadcastResponseData | never> {
+    options?: Types.MessageOptions
+  ): Promise<Types.BroadcastResponseData | never> {
     return this.broadcastMessage(broadcastList, {
       type: 'sticker',
       stickerId,
@@ -493,9 +474,9 @@ export default class ViberClient {
    */
   broadcastCarouselContent(
     broadcastList: string[],
-    richMedia: RichMedia,
-    options?: MessageOptions
-  ): Promise<BroadcastResponseData | never> {
+    richMedia: Types.RichMedia,
+    options?: Types.MessageOptions
+  ): Promise<Types.BroadcastResponseData | never> {
     return this.broadcastMessage(broadcastList, {
       type: 'rich_media',
       minApiVersion: 2,
@@ -509,8 +490,10 @@ export default class ViberClient {
    *
    * https://developers.viber.com/docs/api/rest-bot-api/#get-account-info
    */
-  getAccountInfo(): Promise<SucceededResponseData<AccountInfo> | never> {
-    return this._callAPI<AccountInfo>('/get_account_info');
+  getAccountInfo(): Promise<
+    Types.SucceededResponseData<Types.AccountInfo> | never
+  > {
+    return this._callAPI<Types.AccountInfo>('/get_account_info');
   }
 
   /**
@@ -518,9 +501,9 @@ export default class ViberClient {
    *
    * https://developers.viber.com/docs/api/rest-bot-api/#get-user-details
    */
-  async getUserDetails(id: string): Promise<UserDetails | never> {
+  async getUserDetails(id: string): Promise<Types.UserDetails | never> {
     const { user } = await this._callAPI<{
-      user: UserDetails;
+      user: Types.UserDetails;
     }>('/get_user_details', { id });
 
     return user;
@@ -531,9 +514,11 @@ export default class ViberClient {
    *
    * https://developers.viber.com/docs/api/rest-bot-api/#get-online
    */
-  async getOnlineStatus(ids: string[]): Promise<UserOnlineStatus[] | never> {
+  async getOnlineStatus(
+    ids: string[]
+  ): Promise<Types.UserOnlineStatus[] | never> {
     const data = await this._callAPI<{
-      users: UserOnlineStatus[];
+      users: Types.UserOnlineStatus[];
     }>('/get_online', { ids });
 
     return data.users;

--- a/packages/messaging-api-viber/src/ViberTypes.ts
+++ b/packages/messaging-api-viber/src/ViberTypes.ts
@@ -1,3 +1,12 @@
+import { OnRequestFunction } from 'messaging-api-common';
+
+export type ClientConfig = {
+  accessToken: string;
+  sender: Sender;
+  origin?: string;
+  onRequest?: OnRequestFunction;
+};
+
 export type SucceededResponseData<T extends object> = {
   status: 0;
   statusMessage: 'ok';

--- a/packages/messaging-api-wechat/src/WechatTypes.ts
+++ b/packages/messaging-api-wechat/src/WechatTypes.ts
@@ -1,3 +1,12 @@
+import { OnRequestFunction } from 'messaging-api-common';
+
+export type ClientConfig = {
+  appId: string;
+  appSecret: string;
+  origin?: string;
+  onRequest?: OnRequestFunction;
+};
+
 export type SucceededResponseData = {
   errcode: 0;
   errmsg: 'ok';


### PR DESCRIPTION
This refactor helps us to avoid using destructuring to import TS types which may causes future git conflicts.