### PR TITLE
feat: improve recipient support

### DIFF
--- a/packages/messaging-api-messenger/src/MessengerBatch.ts
+++ b/packages/messaging-api-messenger/src/MessengerBatch.ts
@@ -21,16 +21,16 @@ function sendRequest(
 }
 
 function sendMessage(
-  idOrRecipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   msg: Types.Message,
   options: Types.SendOption & Types.BatchRequestOptions = {}
 ): Types.BatchItem {
   const recipient =
-    typeof idOrRecipient === 'string'
+    typeof psidOrRecipient === 'string'
       ? {
-          id: idOrRecipient,
+          id: psidOrRecipient,
         }
-      : idOrRecipient;
+      : psidOrRecipient;
   let messagingType = 'UPDATE';
   if (options.messagingType) {
     messagingType = options.messagingType;
@@ -52,84 +52,104 @@ function sendMessage(
 }
 
 function sendText(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   text: string,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
-  return sendMessage(recipient, Messenger.createText(text, options), options);
+  return sendMessage(
+    psidOrRecipient,
+    Messenger.createText(text, options),
+    options
+  );
 }
 
 function sendAttachment(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   attachment: Types.Attachment,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createAttachment(attachment, options),
     options
   );
 }
 
 function sendAudio(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   audio: string | Types.MediaAttachmentPayload,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
-  return sendMessage(recipient, Messenger.createAudio(audio, options), options);
+  return sendMessage(
+    psidOrRecipient,
+    Messenger.createAudio(audio, options),
+    options
+  );
 }
 
 function sendImage(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   image: string | Types.MediaAttachmentPayload,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
-  return sendMessage(recipient, Messenger.createImage(image, options), options);
+  return sendMessage(
+    psidOrRecipient,
+    Messenger.createImage(image, options),
+    options
+  );
 }
 
 function sendVideo(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   video: string | Types.MediaAttachmentPayload,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
-  return sendMessage(recipient, Messenger.createVideo(video, options), options);
+  return sendMessage(
+    psidOrRecipient,
+    Messenger.createVideo(video, options),
+    options
+  );
 }
 
 function sendFile(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   file: string | Types.MediaAttachmentPayload,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
-  return sendMessage(recipient, Messenger.createFile(file, options), options);
+  return sendMessage(
+    psidOrRecipient,
+    Messenger.createFile(file, options),
+    options
+  );
 }
 
 function sendTemplate(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   payload: Types.TemplateAttachmentPayload,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createTemplate(payload, options),
     options
   );
 }
 
 function sendButtonTemplate(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   text: string,
   buttons: Types.TemplateButton[],
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createButtonTemplate(text, buttons, options),
     options
   );
 }
 
 function sendGenericTemplate(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   elements: Types.TemplateElement[],
   {
     imageAspectRatio = 'horizontal',
@@ -139,7 +159,7 @@ function sendGenericTemplate(
   } & Types.SendOption = {}
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createGenericTemplate(elements, {
       ...options,
       imageAspectRatio,
@@ -150,72 +170,72 @@ function sendGenericTemplate(
 }
 
 function sendReceiptTemplate(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   attrs: Types.ReceiptAttributes,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createReceiptTemplate(attrs, options),
     options
   );
 }
 
 function sendMediaTemplate(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   elements: Types.MediaElement[],
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createMediaTemplate(elements, options),
     options
   );
 }
 
 function sendAirlineBoardingPassTemplate(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   attrs: Types.AirlineBoardingPassAttributes,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createAirlineBoardingPassTemplate(attrs, options),
     options
   );
 }
 
 function sendAirlineCheckinTemplate(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   attrs: Types.AirlineCheckinAttributes,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createAirlineCheckinTemplate(attrs, options),
     options
   );
 }
 
 function sendAirlineItineraryTemplate(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   attrs: Types.AirlineItineraryAttributes,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createAirlineItineraryTemplate(attrs, options),
     options
   );
 }
 
 function sendAirlineUpdateTemplate(
-  recipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   attrs: Types.AirlineUpdateAttributes,
   options?: Types.SendOption & Types.BatchRequestOptions
 ): Types.BatchItem {
   return sendMessage(
-    recipient,
+    psidOrRecipient,
     Messenger.createAirlineUpdateTemplate(attrs, options),
     options
   );
@@ -237,16 +257,16 @@ function getUserProfile(
 }
 
 function sendSenderAction(
-  idOrRecipient: Types.UserID | Types.Recipient,
+  psidOrRecipient: Types.PsidOrRecipient,
   action: Types.SenderAction,
   options: Types.SendOption & Types.BatchRequestOptions = {}
 ) {
   const recipient =
-    typeof idOrRecipient === 'string'
+    typeof psidOrRecipient === 'string'
       ? {
-          id: idOrRecipient,
+          id: psidOrRecipient,
         }
-      : idOrRecipient;
+      : psidOrRecipient;
 
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
@@ -261,21 +281,21 @@ function sendSenderAction(
 }
 
 function typingOn(
-  idOrRecipient: Types.UserID | Types.Recipient,
+  idOrRecipient: Types.PsidOrRecipient,
   options?: Types.SendOption & Types.BatchRequestOptions
 ) {
   return sendSenderAction(idOrRecipient, 'typing_on', options);
 }
 
 function typingOff(
-  idOrRecipient: Types.UserID | Types.Recipient,
+  idOrRecipient: Types.PsidOrRecipient,
   options?: Types.SendOption & Types.BatchRequestOptions
 ) {
   return sendSenderAction(idOrRecipient, 'typing_off', options);
 }
 
 function markSeen(
-  idOrRecipient: Types.UserID | Types.Recipient,
+  idOrRecipient: Types.PsidOrRecipient,
   options?: Types.SendOption & Types.BatchRequestOptions
 ) {
   return sendSenderAction(idOrRecipient, 'mark_seen', options);
@@ -365,7 +385,7 @@ function getThreadOwner(
 }
 
 function associateLabel(
-  userId: Types.UserID,
+  userId: string,
   labelId: number,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ) {
@@ -383,7 +403,7 @@ function associateLabel(
 }
 
 function dissociateLabel(
-  userId: Types.UserID,
+  userId: string,
   labelId: number,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ): object {
@@ -401,7 +421,7 @@ function dissociateLabel(
 }
 
 function getAssociatedLabels(
-  userId: Types.UserID,
+  userId: string,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ): object {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);

--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -789,16 +789,16 @@ export default class MessengerClient {
   }
 
   sendMessage(
-    idOrRecipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     message: Types.Message,
     options: Types.SendOption = {}
   ): Promise<Types.SendMessageSuccessResponse> {
     const recipient =
-      typeof idOrRecipient === 'string'
+      typeof psidOrRecipient === 'string'
         ? {
-            id: idOrRecipient,
+            id: psidOrRecipient,
           }
-        : idOrRecipient;
+        : psidOrRecipient;
 
     let messagingType = 'UPDATE';
 
@@ -817,16 +817,16 @@ export default class MessengerClient {
   }
 
   sendMessageFormData(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     formdata: FormData,
     options: Types.SendOption = {}
   ) {
-    const recipientObject =
-      typeof recipient === 'string'
+    const recipient =
+      typeof psidOrRecipient === 'string'
         ? {
-            id: recipient,
+            id: psidOrRecipient,
           }
-        : recipient;
+        : psidOrRecipient;
 
     let messagingType = 'UPDATE';
     if (options.messagingType) {
@@ -836,10 +836,7 @@ export default class MessengerClient {
     }
 
     formdata.append('messaging_type', messagingType);
-    formdata.append(
-      'recipient',
-      JSON.stringify(snakecaseKeysDeep(recipientObject))
-    );
+    formdata.append('recipient', JSON.stringify(snakecaseKeysDeep(recipient)));
 
     return this._axios
       .post(
@@ -858,83 +855,83 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/send-messages#content_types
    */
   sendAttachment(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     attachment: Types.Attachment,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createAttachment(attachment, options),
       options
     );
   }
 
   sendText(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     text: string,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createText(text, options),
       options
     );
   }
 
   sendAudio(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     audio: string | Types.FileData | Types.MediaAttachmentPayload,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     if (Buffer.isBuffer(audio) || audio instanceof fs.ReadStream) {
       const message = Messenger.createAudioFormData(audio, options);
-      return this.sendMessageFormData(recipient, message, options);
+      return this.sendMessageFormData(psidOrRecipient, message, options);
     }
 
     const message = Messenger.createAudio(audio, options);
-    return this.sendMessage(recipient, message, options);
+    return this.sendMessage(psidOrRecipient, message, options);
   }
 
   sendImage(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     image: string | Types.FileData | Types.MediaAttachmentPayload,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     if (Buffer.isBuffer(image) || image instanceof fs.ReadStream) {
       const message = Messenger.createImageFormData(image, options);
-      return this.sendMessageFormData(recipient, message, options);
+      return this.sendMessageFormData(psidOrRecipient, message, options);
     }
 
     const message = Messenger.createImage(image, options);
-    return this.sendMessage(recipient, message, options);
+    return this.sendMessage(psidOrRecipient, message, options);
   }
 
   sendVideo(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     video: string | Types.FileData | Types.MediaAttachmentPayload,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     if (Buffer.isBuffer(video) || video instanceof fs.ReadStream) {
       const message = Messenger.createVideoFormData(video, options);
-      return this.sendMessageFormData(recipient, message, options);
+      return this.sendMessageFormData(psidOrRecipient, message, options);
     }
 
     const message = Messenger.createVideo(video, options);
-    return this.sendMessage(recipient, message, options);
+    return this.sendMessage(psidOrRecipient, message, options);
   }
 
   sendFile(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     file: string | Types.FileData | Types.MediaAttachmentPayload,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     if (Buffer.isBuffer(file) || file instanceof fs.ReadStream) {
       const message = Messenger.createFileFormData(file, options);
-      return this.sendMessageFormData(recipient, message, options);
+      return this.sendMessageFormData(psidOrRecipient, message, options);
     }
 
     const message = Messenger.createFile(file, options);
-    return this.sendMessage(recipient, message, options);
+    return this.sendMessage(psidOrRecipient, message, options);
   }
 
   /**
@@ -943,12 +940,12 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/send-messages/templates
    */
   sendTemplate(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     payload: Types.TemplateAttachmentPayload,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createTemplate(payload, options),
       options
     );
@@ -956,13 +953,13 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/button
   sendButtonTemplate(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     text: string,
     buttons: Types.TemplateButton[],
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createButtonTemplate(text, buttons, options),
       options
     );
@@ -970,14 +967,14 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic
   sendGenericTemplate(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     elements: Types.TemplateElement[],
     options: {
       imageAspectRatio?: 'horizontal' | 'square';
     } & Types.SendOption = {}
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createGenericTemplate(elements, options),
       omit(options, ['imageAspectRatio'])
     );
@@ -985,12 +982,12 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/receipt
   sendReceiptTemplate(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     attrs: Types.ReceiptAttributes,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createReceiptTemplate(attrs, options),
       options
     );
@@ -998,12 +995,12 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/media
   sendMediaTemplate(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     elements: Types.MediaElement[],
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createMediaTemplate(elements, options),
       options
     );
@@ -1011,12 +1008,12 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/airline#boarding_pass
   sendAirlineBoardingPassTemplate(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     attrs: Types.AirlineBoardingPassAttributes,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createAirlineBoardingPassTemplate(attrs, options),
       options
     );
@@ -1024,12 +1021,12 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/airline#check_in
   sendAirlineCheckinTemplate(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     attrs: Types.AirlineCheckinAttributes,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createAirlineCheckinTemplate(attrs, options),
       options
     );
@@ -1037,12 +1034,12 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/airline#itinerary
   sendAirlineItineraryTemplate(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     attrs: Types.AirlineItineraryAttributes,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createAirlineItineraryTemplate(attrs, options),
       options
     );
@@ -1050,12 +1047,12 @@ export default class MessengerClient {
 
   // https://developers.facebook.com/docs/messenger-platform/send-messages/template/airline#update
   sendAirlineUpdateTemplate(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     attrs: Types.AirlineUpdateAttributes,
     options?: Types.SendOption
   ): Promise<Types.SendMessageSuccessResponse> {
     return this.sendMessage(
-      recipient,
+      psidOrRecipient,
       Messenger.createAirlineUpdateTemplate(attrs, options),
       options
     );
@@ -1067,16 +1064,16 @@ export default class MessengerClient {
    * https://developers.facebook.com/docs/messenger-platform/send-messages/sender-actions
    */
   sendSenderAction(
-    idOrRecipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     action: Types.SenderAction,
     { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ): Promise<Types.SendSenderActionResponse> {
     const recipient =
-      typeof idOrRecipient === 'string'
+      typeof psidOrRecipient === 'string'
         ? {
-            id: idOrRecipient,
+            id: psidOrRecipient,
           }
-        : idOrRecipient;
+        : psidOrRecipient;
     return this.sendRawBody({
       recipient,
       senderAction: action,
@@ -1085,24 +1082,24 @@ export default class MessengerClient {
   }
 
   markSeen(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     options: Record<string, any> = {}
   ): Promise<Types.SendSenderActionResponse> {
-    return this.sendSenderAction(recipient, 'mark_seen', options);
+    return this.sendSenderAction(psidOrRecipient, 'mark_seen', options);
   }
 
   typingOn(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     options: Record<string, any> = {}
   ): Promise<Types.SendSenderActionResponse> {
-    return this.sendSenderAction(recipient, 'typing_on', options);
+    return this.sendSenderAction(psidOrRecipient, 'typing_on', options);
   }
 
   typingOff(
-    recipient: Types.UserID | Types.Recipient,
+    psidOrRecipient: Types.PsidOrRecipient,
     options: Record<string, any> = {}
   ): Promise<Types.SendSenderActionResponse> {
-    return this.sendSenderAction(recipient, 'typing_off', options);
+    return this.sendSenderAction(psidOrRecipient, 'typing_off', options);
   }
 
   /**
@@ -1204,7 +1201,7 @@ export default class MessengerClient {
    */
   // FIXME: [type] return type
   associateLabel(
-    userId: Types.UserID,
+    userId: string,
     labelId: number,
     { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
@@ -1226,7 +1223,7 @@ export default class MessengerClient {
    */
   // FIXME: [type] return type
   dissociateLabel(
-    userId: Types.UserID,
+    userId: string,
     labelId: number,
     { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
@@ -1248,7 +1245,7 @@ export default class MessengerClient {
    */
   // FIXME: [type] return type
   getAssociatedLabels(
-    userId: Types.UserID,
+    userId: string,
     options: { accessToken?: string; fields?: string[] } = {}
   ) {
     const fields = options.fields ? options.fields.join(',') : 'name';
@@ -1635,7 +1632,7 @@ export default class MessengerClient {
   }: {
     appId: number;
     pageId: number;
-    pageScopedUserId: Types.UserID;
+    pageScopedUserId: string;
     events: Record<string, any>[];
   }) {
     return this._axios

--- a/packages/messaging-api-messenger/src/MessengerTypes.ts
+++ b/packages/messaging-api-messenger/src/MessengerTypes.ts
@@ -12,18 +12,56 @@ export type ClientConfig = {
   skipAppSecretProof?: boolean;
 };
 
-export type UserID = string;
-
+/**
+ * Page Scoped User ID (PSID) of the message recipient.
+ */
 export type RecipientWithID = {
-  id: UserID;
+  id: string;
 };
 
+/**
+ * Used for Customer Matching. (Closed Beta)
+ */
 export type RecipientWithPhoneNumber = {
   phoneNumber: string;
   name?: Record<string, any>;
 };
 
-export type Recipient = RecipientWithID | RecipientWithPhoneNumber;
+/**
+ * Used for the checkbox plugin.
+ */
+export type RecipientWithUserRef = {
+  userRef: string;
+};
+
+/**
+ * Used for Private Replies to reference the visitor post to reply to.
+ */
+export type RecipientWithPostId = {
+  postId: string;
+};
+
+/**
+ * Used for Private Replies to reference the post comment to reply to.
+ */
+export type RecipientWithCommentId = {
+  commentId: string;
+};
+
+/**
+ * Description of the message recipient. All requests must include one to identify the recipient.
+ */
+export type Recipient =
+  | RecipientWithID
+  | RecipientWithPhoneNumber
+  | RecipientWithUserRef
+  | RecipientWithPostId
+  | RecipientWithCommentId;
+
+/**
+ * Description of the message recipient. If a string is provided, it will be recognized as a psid.
+ */
+export type PsidOrRecipient = string | Recipient;
 
 export type UrlMediaAttachmentPayload = {
   url: string;
@@ -423,14 +461,6 @@ export type BatchRequestOptions = {
   dependsOn?: string;
 };
 
-export type BatchItem = {
-  method: string;
-  relativeUrl: string;
-  name?: string;
-  body?: Record<string, any>;
-  responseAccessPath?: string;
-} & BatchRequestOptions;
-
 export type Model =
   | 'CUSTOM'
   | 'CHINESE'
@@ -502,3 +532,11 @@ export type MessengerSubscription = {
   active: boolean;
   fields: SubscriptionFields[];
 };
+
+export type BatchItem = {
+  method: string;
+  relativeUrl: string;
+  name?: string;
+  body?: Record<string, any>;
+  responseAccessPath?: string;
+} & BatchRequestOptions;

--- a/packages/messaging-api-messenger/src/__tests__/MessengerBatch.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerBatch.spec.ts
@@ -131,6 +131,75 @@ describe('sendMessage', () => {
     });
   });
 
+  it('can create request with user_ref', () => {
+    expect(
+      MessengerBatch.sendMessage(
+        {
+          userRef: 'user-ref',
+        },
+        { text: 'Hello' }
+      )
+    ).toEqual({
+      method: 'POST',
+      relativeUrl: 'me/messages',
+      body: {
+        messagingType: 'UPDATE',
+        message: {
+          text: 'Hello',
+        },
+        recipient: {
+          userRef: 'user-ref',
+        },
+      },
+    });
+  });
+
+  it('can create request with post_id', () => {
+    expect(
+      MessengerBatch.sendMessage(
+        {
+          postId: 'post-id',
+        },
+        { text: 'Hello' }
+      )
+    ).toEqual({
+      method: 'POST',
+      relativeUrl: 'me/messages',
+      body: {
+        messagingType: 'UPDATE',
+        message: {
+          text: 'Hello',
+        },
+        recipient: {
+          postId: 'post-id',
+        },
+      },
+    });
+  });
+
+  it('can create request with comment_id', () => {
+    expect(
+      MessengerBatch.sendMessage(
+        {
+          commentId: 'comment-id',
+        },
+        { text: 'Hello' }
+      )
+    ).toEqual({
+      method: 'POST',
+      relativeUrl: 'me/messages',
+      body: {
+        messagingType: 'UPDATE',
+        message: {
+          text: 'Hello',
+        },
+        recipient: {
+          commentId: 'comment-id',
+        },
+      },
+    });
+  });
+
   it('should omit options with undefined value', () => {
     expect(
       MessengerBatch.sendMessage(

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.ts
@@ -257,7 +257,6 @@ describe('send api', () => {
       const { client, mock } = createMock();
 
       const reply = {
-        recipient_id: USER_ID,
         message_id: 'mid.1489394984387:3dd22de509',
       };
 
@@ -287,6 +286,135 @@ describe('send api', () => {
         recipient: {
           phone_number: '+1(212)555-2368',
           name: { first_name: 'John', last_name: 'Doe' },
+        },
+        message: {
+          text: 'Hello!',
+        },
+      });
+
+      expect(res).toEqual({
+        messageId: 'mid.1489394984387:3dd22de509',
+      });
+    });
+
+    it('can call messages api using recipient with user_ref', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {
+        message_id: 'mid.1489394984387:3dd22de509',
+      };
+
+      let url;
+      let data;
+      mock.onPost().reply(config => {
+        url = config.url;
+        data = config.data;
+        return [200, reply];
+      });
+
+      const res = await client.sendMessage(
+        {
+          userRef: 'ref',
+        },
+        {
+          text: 'Hello!',
+        }
+      );
+
+      expect(url).toEqual(
+        `https://graph.facebook.com/v4.0/me/messages?access_token=${ACCESS_TOKEN}`
+      );
+      expect(JSON.parse(data)).toEqual({
+        messaging_type: 'UPDATE',
+        recipient: {
+          user_ref: 'ref',
+        },
+        message: {
+          text: 'Hello!',
+        },
+      });
+
+      expect(res).toEqual({
+        messageId: 'mid.1489394984387:3dd22de509',
+      });
+    });
+
+    it('can call messages api using recipient with post_id', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {
+        recipient_id: USER_ID,
+        message_id: 'mid.1489394984387:3dd22de509',
+      };
+
+      let url;
+      let data;
+      mock.onPost().reply(config => {
+        url = config.url;
+        data = config.data;
+        return [200, reply];
+      });
+
+      const res = await client.sendMessage(
+        {
+          postId: 'post-id',
+        },
+        {
+          text: 'Hello!',
+        }
+      );
+
+      expect(url).toEqual(
+        `https://graph.facebook.com/v4.0/me/messages?access_token=${ACCESS_TOKEN}`
+      );
+      expect(JSON.parse(data)).toEqual({
+        messaging_type: 'UPDATE',
+        recipient: {
+          post_id: 'post-id',
+        },
+        message: {
+          text: 'Hello!',
+        },
+      });
+
+      expect(res).toEqual({
+        recipientId: USER_ID,
+        messageId: 'mid.1489394984387:3dd22de509',
+      });
+    });
+
+    it('can call messages api using recipient with comment_id', async () => {
+      const { client, mock } = createMock();
+
+      const reply = {
+        recipient_id: USER_ID,
+        message_id: 'mid.1489394984387:3dd22de509',
+      };
+
+      let url;
+      let data;
+      mock.onPost().reply(config => {
+        url = config.url;
+        data = config.data;
+        return [200, reply];
+      });
+
+      const res = await client.sendMessage(
+        {
+          commentId: 'comment-id',
+        },
+        {
+          text: 'Hello!',
+        }
+      );
+
+      expect(url).toEqual(
+        `https://graph.facebook.com/v4.0/me/messages?access_token=${ACCESS_TOKEN}`
+      );
+      expect(JSON.parse(data)).toEqual({
+        messaging_type: 'UPDATE',
+        recipient: {
+          comment_id: 'comment-id',
         },
         message: {
           text: 'Hello!',


### PR DESCRIPTION
Add types and tests for using `user_ref`, `post_id` and `comment_id` to send messages.

```js
export type Recipient =
  | RecipientWithID
  | RecipientWithPhoneNumber
  | RecipientWithUserRef
  | RecipientWithPostId
  | RecipientWithCommentId;
```