### PR TITLE
fix: change ScheduleMessageOptions 'channelId' to 'channel'

### DIFF
--- a/packages/messaging-api-slack/src/SlackTypes.ts
+++ b/packages/messaging-api-slack/src/SlackTypes.ts
@@ -614,7 +614,7 @@ export type DeleteScheduledMessageOptions = CommonOptions & {
 // https://api.slack.com/methods/chat.scheduleMessage
 export type ScheduleMessageOptions = CommonOptions &
   Message & {
-    channelId: string;
+    channel: string;
     asUser?: boolean;
     attachments?: string | Attachment[];
     linkNames?: boolean;


### PR DESCRIPTION
ref: https://api.slack.com/methods/chat.scheduleMessage

change to correct field name