### PR TITLE
refactor(messenger): improve typing for sender action

### DIFF
--- a/packages/messaging-api-messenger/src/MessengerBatch.ts
+++ b/packages/messaging-api-messenger/src/MessengerBatch.ts
@@ -258,7 +258,7 @@ function getUserProfile(
 
 function sendSenderAction(
   psidOrRecipient: Types.PsidOrRecipient,
-  action: Types.SenderAction,
+  senderAction: Types.SenderAction,
   options: Types.SendOption & Types.BatchRequestOptions = {}
 ) {
   const recipient =
@@ -273,7 +273,7 @@ function sendSenderAction(
   return sendRequest(
     {
       recipient,
-      senderAction: action,
+      senderAction,
       ...omitUndefinedFields(omit(options, ['name', 'dependsOn'])),
     },
     batchRequestOptions

--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -1065,7 +1065,7 @@ export default class MessengerClient {
    */
   sendSenderAction(
     psidOrRecipient: Types.PsidOrRecipient,
-    action: Types.SenderAction,
+    senderAction: Types.SenderAction,
     { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ): Promise<Types.SendSenderActionResponse> {
     const recipient =
@@ -1076,7 +1076,7 @@ export default class MessengerClient {
         : psidOrRecipient;
     return this.sendRawBody({
       recipient,
-      senderAction: action,
+      senderAction,
       accessToken: customAccessToken,
     });
   }

--- a/packages/messaging-api-messenger/src/MessengerTypes.ts
+++ b/packages/messaging-api-messenger/src/MessengerTypes.ts
@@ -380,7 +380,7 @@ export type AirlineUpdateAttributes = {
   updateFlightInfo: UpdateFlightInfo;
 };
 
-export type SenderAction = string;
+export type SenderAction = 'mark_seen' | 'typing_on' | 'typing_off';
 
 export type User = {
   firstName: string;


### PR DESCRIPTION
from

```ts
type SenderAction = string;
```

to

```ts
type SenderAction = 'mark_seen' | 'typing_on' | 'typing_off';
```