### PR TITLE
Add Sender property to Types.MessageOptions object

### DIFF
--- a/packages/messaging-api-line/src/LineTypes.ts
+++ b/packages/messaging-api-line/src/LineTypes.ts
@@ -153,8 +153,14 @@ export type QuickReply = {
   }[];
 };
 
+export type Sender = {
+  name?: string;
+  iconUrl?: string;
+};
+
 export type MessageOptions = {
   quickReply?: QuickReply;
+  sender?: Sender;
 };
 
 export type TemplateMessage<Template> = {

--- a/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.ts
@@ -216,7 +216,7 @@ describe('Reply Message', () => {
 
       expect(res).toEqual(reply);
     });
-    
+
     it('should work with custom access token', async () => {
       expect.assertions(4);
 

--- a/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.ts
@@ -216,6 +216,7 @@ describe('Reply Message', () => {
 
       expect(res).toEqual(reply);
     });
+    
     it('should work with custom access token', async () => {
       expect.assertions(4);
 

--- a/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.ts
@@ -181,6 +181,41 @@ describe('Reply Message', () => {
       expect(res).toEqual(reply);
     });
 
+    it('should call reply api and sender', async () => {
+      expect.assertions(4);
+
+      const { client, mock, headers } = createMock();
+
+      const reply = {};
+
+      mock.onPost().reply(config => {
+        expect(config.url).toEqual('https://api.line.me/v2/bot/message/reply');
+        expect(JSON.parse(config.data)).toEqual({
+          replyToken: REPLY_TOKEN,
+          messages: [
+            {
+              type: 'text',
+              text: 'Hello!',
+              sender: {
+                name: 'Cony',
+                iconUrl: 'https://example.com/original.jpg',
+              },
+            },
+          ],
+        });
+        expect(config.headers).toEqual(headers);
+        return [200, reply];
+      });
+
+      const res = await client.replyText(REPLY_TOKEN, 'Hello!', {
+        sender: {
+          name: 'Cony',
+          iconUrl: 'https://example.com/original.jpg',
+        },
+      });
+
+      expect(res).toEqual(reply);
+    });
     it('should work with custom access token', async () => {
       expect.assertions(4);
 


### PR DESCRIPTION
refs: https://developers.line.biz/en/reference/messaging-api/#icon-nickname-switch