### PR TITLE
fix: update some LINE endpoint

### DIFF
--- a/packages/messaging-api-line/src/LineClient.ts
+++ b/packages/messaging-api-line/src/LineClient.ts
@@ -55,6 +55,8 @@ export default class LineClient {
 
   _axios: AxiosInstance;
 
+  _dataAxios: AxiosInstance;
+
   _accessToken: string;
 
   constructor(
@@ -62,6 +64,7 @@ export default class LineClient {
     channelSecret?: string
   ) {
     let origin;
+    let dataOrigin;
     if (accessTokenOrConfig && typeof accessTokenOrConfig === 'object') {
       const config = accessTokenOrConfig;
 
@@ -69,6 +72,7 @@ export default class LineClient {
       this._channelSecret = config.channelSecret;
       this._onRequest = config.onRequest;
       origin = config.origin;
+      dataOrigin = config.dataOrigin;
     } else {
       this._accessToken = accessTokenOrConfig;
       this._channelSecret = channelSecret as string;
@@ -85,10 +89,26 @@ export default class LineClient {
     this._axios.interceptors.request.use(
       createRequestInterceptor({ onRequest: this._onRequest })
     );
+
+    this._dataAxios = axios.create({
+      baseURL: `${dataOrigin || 'https://api-data.line.me'}/`,
+      headers: {
+        Authorization: `Bearer ${this._accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    this._dataAxios.interceptors.request.use(
+      createRequestInterceptor({ onRequest: this._onRequest })
+    );
   }
 
   get axios(): AxiosInstance {
     return this._axios;
+  }
+
+  get dataAxios(): AxiosInstance {
+    return this._dataAxios;
   }
 
   get accessToken(): string {
@@ -805,7 +825,7 @@ export default class LineClient {
     messageId: string,
     { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ): Promise<Buffer> {
-    return this._axios
+    return this._dataAxios
       .get(`/v2/bot/message/${messageId}/content`, {
         responseType: 'arraybuffer',
         ...(customAccessToken
@@ -1236,7 +1256,7 @@ export default class LineClient {
       'Image must be `image/jpeg` or `image/png`'
     );
 
-    return this._axios
+    return this._dataAxios
       .post(`/v2/bot/richmenu/${richMenuId}/content`, image, {
         headers: {
           'Content-Type': (type as { mime: string }).mime,
@@ -1252,7 +1272,7 @@ export default class LineClient {
     richMenuId: string,
     { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
   ) {
-    return this._axios
+    return this._dataAxios
       .get(`/v2/bot/richmenu/${richMenuId}/content`, {
         responseType: 'arraybuffer',
         headers: {

--- a/packages/messaging-api-line/src/LineTypes.ts
+++ b/packages/messaging-api-line/src/LineTypes.ts
@@ -4,6 +4,7 @@ export type ClientConfig = {
   accessToken: string;
   channelSecret: string;
   origin?: string;
+  dataOrigin?: string;
   onRequest?: OnRequestFunction;
 };
 

--- a/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.ts
@@ -14,6 +14,7 @@ const createMock = ({
 }: { customAccessToken?: string } = {}): {
   client: LineClient;
   mock: MockAdapter;
+  dataMock: MockAdapter;
   headers: {
     Accept: string;
     'Content-Type': string;
@@ -22,12 +23,13 @@ const createMock = ({
 } => {
   const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
   const mock = new MockAdapter(client.axios);
+  const dataMock = new MockAdapter(client.dataAxios);
   const headers = {
     Accept: 'application/json, text/plain, */*',
     'Content-Type': 'application/json',
     Authorization: `Bearer ${customAccessToken || ACCESS_TOKEN}`,
   };
-  return { client, mock, headers };
+  return { client, mock, dataMock, headers };
 };
 
 describe('Rich Menu', () => {
@@ -598,7 +600,7 @@ describe('Rich Menu', () => {
     it('should call api', async () => {
       expect.assertions(4);
 
-      const { client, mock, headers } = createMock();
+      const { client, dataMock, headers } = createMock();
 
       const reply = {};
 
@@ -612,9 +614,9 @@ describe('Rich Menu', () => {
         });
       });
 
-      mock.onPost().reply(config => {
+      dataMock.onPost().reply(config => {
         expect(config.url).toEqual(
-          'https://api.line.me/v2/bot/richmenu/1/content'
+          'https://api-data.line.me/v2/bot/richmenu/1/content'
         );
         expect(config.data).toEqual(buffer);
         expect(config.headers).toEqual({
@@ -632,7 +634,7 @@ describe('Rich Menu', () => {
     it('should work with custom access token', async () => {
       expect.assertions(4);
 
-      const { client, mock, headers } = createMock({
+      const { client, dataMock, headers } = createMock({
         customAccessToken: CUSTOM_ACCESS_TOKEN,
       });
 
@@ -648,9 +650,9 @@ describe('Rich Menu', () => {
         });
       });
 
-      mock.onPost().reply(config => {
+      dataMock.onPost().reply(config => {
         expect(config.url).toEqual(
-          'https://api.line.me/v2/bot/richmenu/1/content'
+          'https://api-data.line.me/v2/bot/richmenu/1/content'
         );
         expect(config.data).toEqual(buffer);
         expect(config.headers).toEqual({
@@ -670,13 +672,13 @@ describe('Rich Menu', () => {
     it('should throw error when ', async () => {
       expect.assertions(1);
 
-      const { client, mock, headers } = createMock();
+      const { client, dataMock, headers } = createMock();
 
       const reply = {};
 
-      mock.onPost().reply(config => {
+      dataMock.onPost().reply(config => {
         expect(config.url).toEqual(
-          'https://api.line.me/v2/bot/richmenu/1/content'
+          'https://api-data.line.me/v2/bot/richmenu/1/content'
         );
         expect(config.data).toEqual(undefined);
         expect(config.headers).toEqual(headers);
@@ -698,13 +700,13 @@ describe('Rich Menu', () => {
     it('should call api', async () => {
       expect.assertions(4);
 
-      const { client, mock, headers } = createMock();
+      const { client, dataMock, headers } = createMock();
 
       const reply = Buffer.from('a content buffer');
 
-      mock.onGet().reply(config => {
+      dataMock.onGet().reply(config => {
         expect(config.url).toEqual(
-          'https://api.line.me/v2/bot/richmenu/1/content'
+          'https://api-data.line.me/v2/bot/richmenu/1/content'
         );
         expect(config.data).toEqual(undefined);
         expect(config.headers).toEqual(headers);
@@ -718,15 +720,15 @@ describe('Rich Menu', () => {
 
     it('should work with custom access token', async () => {
       expect.assertions(4);
-      const { client, mock, headers } = createMock({
+      const { client, dataMock, headers } = createMock({
         customAccessToken: CUSTOM_ACCESS_TOKEN,
       });
 
       const reply = Buffer.from('a content buffer');
 
-      mock.onGet().reply(config => {
+      dataMock.onGet().reply(config => {
         expect(config.url).toEqual(
-          'https://api.line.me/v2/bot/richmenu/1/content'
+          'https://api-data.line.me/v2/bot/richmenu/1/content'
         );
         expect(config.data).toEqual(undefined);
         expect(config.headers).toEqual(headers);
@@ -741,9 +743,9 @@ describe('Rich Menu', () => {
     });
 
     it('should return null when no rich menu image found', async () => {
-      const { client, mock } = createMock();
+      const { client, dataMock } = createMock();
 
-      mock.onGet().reply(404, Buffer.from('{"message":"Not found"}'));
+      dataMock.onGet().reply(404, Buffer.from('{"message":"Not found"}'));
 
       const res = await client.downloadRichMenuImage(
         'richmenu-8dfdfc571eca39c0ffcd1f799519c5b5'

--- a/packages/messaging-api-line/src/__tests__/LineClient.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient.spec.ts
@@ -13,6 +13,7 @@ const createMock = ({
 }: { customAccessToken?: string } = {}): {
   client: LineClient;
   mock: MockAdapter;
+  dataMock: MockAdapter;
   headers: {
     Accept: string;
     'Content-Type': string;
@@ -21,24 +22,25 @@ const createMock = ({
 } => {
   const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
   const mock = new MockAdapter(client.axios);
+  const dataMock = new MockAdapter(client.dataAxios);
   const headers = {
     Accept: 'application/json, text/plain, */*',
     'Content-Type': 'application/json',
     Authorization: `Bearer ${customAccessToken || ACCESS_TOKEN}`,
   };
-  return { client, mock, headers };
+  return { client, mock, dataMock, headers };
 };
 
 describe('Content', () => {
   describe('#getMessageContent', () => {
     it('should call getMessageContent api', async () => {
-      const { client, mock } = createMock();
+      const { client, dataMock } = createMock();
 
       const reply = Buffer.from('a content buffer');
 
       const MESSAGE_ID = '1234567890';
 
-      mock.onGet(`/v2/bot/message/${MESSAGE_ID}/content`).reply(200, reply);
+      dataMock.onGet(`/v2/bot/message/${MESSAGE_ID}/content`).reply(200, reply);
 
       const res = await client.getMessageContent(MESSAGE_ID);
 


### PR DESCRIPTION
Change the endpoint of api call in the following methods:
- LineClient#getMessageContent
- LineClient#uploadRichMenuImage
- LineClient#downloadRichMenuImage

reference: https://developers.line.biz/en/news/2019/11/08/domain-name-change/

