### PR TITLE
feat(message): support One-Time Notification

### DIFF
--- a/packages/messaging-api-messenger/src/Messenger.ts
+++ b/packages/messaging-api-messenger/src/Messenger.ts
@@ -341,6 +341,19 @@ function createAirlineUpdateTemplate(
   );
 }
 
+function createOneTimeNotifReqTemplate(
+  attrs: Types.OneTimeNotifReqAttributes,
+  options?: { quickReplies?: Types.QuickReply[] }
+): Types.Message {
+  return createTemplate(
+    {
+      templateType: 'one_time_notif_req',
+      ...attrs,
+    },
+    options
+  );
+}
+
 const Messenger = {
   createMessage,
   createText,
@@ -362,6 +375,7 @@ const Messenger = {
   createAirlineCheckinTemplate,
   createAirlineItineraryTemplate,
   createAirlineUpdateTemplate,
+  createOneTimeNotifReqTemplate,
 };
 
 export default Messenger;

--- a/packages/messaging-api-messenger/src/MessengerBatch.ts
+++ b/packages/messaging-api-messenger/src/MessengerBatch.ts
@@ -241,13 +241,25 @@ function sendAirlineUpdateTemplate(
   );
 }
 
+function sendOneTimeNotifReqTemplate(
+  psidOrRecipient: Types.PsidOrRecipient,
+  attrs: Types.OneTimeNotifReqAttributes,
+  options?: Types.SendOption & Types.BatchRequestOptions
+): Types.BatchItem {
+  return sendMessage(
+    psidOrRecipient,
+    Messenger.createOneTimeNotifReqTemplate(attrs, options),
+    options
+  );
+}
+
 function getUserProfile(
   userId: string,
   options: {
     fields?: Types.UserProfileField[];
     accessToken?: string;
   } & Types.BatchRequestOptions = {}
-) {
+): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
   const fields = options.fields || [
@@ -271,7 +283,7 @@ function sendSenderAction(
   psidOrRecipient: Types.PsidOrRecipient,
   senderAction: Types.SenderAction,
   options: Types.SendOption & Types.BatchRequestOptions = {}
-) {
+): Types.BatchItem {
   const recipient =
     typeof psidOrRecipient === 'string'
       ? {
@@ -294,21 +306,21 @@ function sendSenderAction(
 function typingOn(
   idOrRecipient: Types.PsidOrRecipient,
   options?: Types.SendOption & Types.BatchRequestOptions
-) {
+): Types.BatchItem {
   return sendSenderAction(idOrRecipient, 'typing_on', options);
 }
 
 function typingOff(
   idOrRecipient: Types.PsidOrRecipient,
   options?: Types.SendOption & Types.BatchRequestOptions
-) {
+): Types.BatchItem {
   return sendSenderAction(idOrRecipient, 'typing_off', options);
 }
 
 function markSeen(
   idOrRecipient: Types.PsidOrRecipient,
   options?: Types.SendOption & Types.BatchRequestOptions
-) {
+): Types.BatchItem {
   return sendSenderAction(idOrRecipient, 'mark_seen', options);
 }
 
@@ -317,7 +329,7 @@ function passThreadControl(
   targetAppId: number,
   metadata: string,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
-) {
+): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
   return {
@@ -337,7 +349,7 @@ function passThreadControlToPageInbox(
   recipientId: string,
   metadata: string,
   options: { accessToken?: string } = {}
-) {
+): Types.BatchItem {
   return passThreadControl(recipientId, 263902037430900, metadata, options);
 }
 
@@ -345,7 +357,7 @@ function takeThreadControl(
   recipientId: string,
   metadata: string,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
-) {
+): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
   return {
@@ -364,7 +376,7 @@ function requestThreadControl(
   recipientId: string,
   metadata: string,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
-) {
+): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
   return {
@@ -382,7 +394,7 @@ function requestThreadControl(
 function getThreadOwner(
   recipientId: string,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
-) {
+): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
   return {
@@ -399,7 +411,7 @@ function associateLabel(
   userId: string,
   labelId: number,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
-) {
+): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
   return {
@@ -417,7 +429,7 @@ function dissociateLabel(
   userId: string,
   labelId: number,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
-): object {
+): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
   return {
@@ -434,7 +446,7 @@ function dissociateLabel(
 function getAssociatedLabels(
   userId: string,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
-): object {
+): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
 
   return {
@@ -464,6 +476,7 @@ const MessengerBatch = {
   sendAirlineCheckinTemplate,
   sendAirlineItineraryTemplate,
   sendAirlineUpdateTemplate,
+  sendOneTimeNotifReqTemplate,
 
   getUserProfile,
 

--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -1058,6 +1058,19 @@ export default class MessengerClient {
     );
   }
 
+  // https://developers.facebook.com/docs/messenger-platform/send-messages/one-time-notification/#one-time-notif
+  sendOneTimeNotifReqTemplate(
+    psidOrRecipient: Types.PsidOrRecipient,
+    attrs: Types.OneTimeNotifReqAttributes,
+    options?: Types.SendOption
+  ): Promise<Types.SendMessageSuccessResponse> {
+    return this.sendMessage(
+      psidOrRecipient,
+      Messenger.createOneTimeNotifReqTemplate(attrs, options),
+      options
+    );
+  }
+
   /**
    * Typing
    *

--- a/packages/messaging-api-messenger/src/MessengerTypes.ts
+++ b/packages/messaging-api-messenger/src/MessengerTypes.ts
@@ -49,6 +49,13 @@ export type RecipientWithCommentId = {
 };
 
 /**
+ * Used for the Messenger Platform's One-Time Notification API.
+ */
+export type RecipientWithOneTimeNotifToken = {
+  oneTimeNotifToken: string;
+};
+
+/**
  * Description of the message recipient. All requests must include one to identify the recipient.
  */
 export type Recipient =
@@ -56,7 +63,8 @@ export type Recipient =
   | RecipientWithPhoneNumber
   | RecipientWithUserRef
   | RecipientWithPostId
-  | RecipientWithCommentId;
+  | RecipientWithCommentId
+  | RecipientWithOneTimeNotifToken;
 
 /**
  * Description of the message recipient. If a string is provided, it will be recognized as a psid.
@@ -106,7 +114,8 @@ export type TemplateAttachmentPayload = {
     | 'airline_boardingpass'
     | 'airline_checkin'
     | 'airline_itinerary'
-    | 'airline_update';
+    | 'airline_update'
+    | 'one_time_notif_req';
   [key: string]: any; // FIXME: list all of templates
 };
 
@@ -378,6 +387,11 @@ export type AirlineUpdateAttributes = {
   locale: string;
   pnrNumber?: string;
   updateFlightInfo: UpdateFlightInfo;
+};
+
+export type OneTimeNotifReqAttributes = {
+  title: string;
+  payload: string;
 };
 
 export type SenderAction = 'mark_seen' | 'typing_on' | 'typing_off';

--- a/packages/messaging-api-messenger/src/__tests__/MessengerBatch.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerBatch.spec.ts
@@ -1060,6 +1060,36 @@ describe('sendAirlineUpdateTemplate', () => {
   });
 });
 
+describe('sendOneTimeNotifReqTemplate', () => {
+  it('should create send one time notif req template request', () => {
+    expect(
+      MessengerBatch.sendOneTimeNotifReqTemplate(RECIPIENT_ID, {
+        title: '<TITLE_TEXT>',
+        payload: '<USER_DEFINED_PAYLOAD>',
+      })
+    ).toEqual({
+      method: 'POST',
+      relativeUrl: 'me/messages',
+      body: {
+        messagingType: 'UPDATE',
+        message: {
+          attachment: {
+            type: 'template',
+            payload: {
+              templateType: 'one_time_notif_req',
+              title: '<TITLE_TEXT>',
+              payload: '<USER_DEFINED_PAYLOAD>',
+            },
+          },
+        },
+        recipient: {
+          id: RECIPIENT_ID,
+        },
+      },
+    });
+  });
+});
+
 describe('getUserProfile', () => {
   it('should create get user profile request', () => {
     expect(MessengerBatch.getUserProfile(RECIPIENT_ID)).toEqual({

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-sendTemplate.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-sendTemplate.spec.ts
@@ -1298,3 +1298,52 @@ describe('#sendAirlineUpdateTemplate', () => {
     });
   });
 });
+
+describe('#sendOneTimeNotifReqTemplate', () => {
+  it('should call messages api with one time notif req template', async () => {
+    const { client, mock } = createMock();
+
+    const reply = {
+      recipient_id: USER_ID,
+      message_id: 'mid.1489394984387:3dd22de509',
+    };
+
+    let url;
+    let data;
+    mock.onPost().reply(config => {
+      url = config.url;
+      data = config.data;
+      return [200, reply];
+    });
+
+    const res = await client.sendOneTimeNotifReqTemplate(USER_ID, {
+      title: '<TITLE_TEXT>',
+      payload: '<USER_DEFINED_PAYLOAD>',
+    });
+
+    expect(url).toEqual(
+      `https://graph.facebook.com/v4.0/me/messages?access_token=${ACCESS_TOKEN}`
+    );
+    expect(JSON.parse(data)).toEqual({
+      messaging_type: 'UPDATE',
+      recipient: {
+        id: USER_ID,
+      },
+      message: {
+        attachment: {
+          type: 'template',
+          payload: {
+            template_type: 'one_time_notif_req',
+            title: '<TITLE_TEXT>',
+            payload: '<USER_DEFINED_PAYLOAD>',
+          },
+        },
+      },
+    });
+
+    expect(res).toEqual({
+      recipientId: USER_ID,
+      messageId: 'mid.1489394984387:3dd22de509',
+    });
+  });
+});


### PR DESCRIPTION
Add support for https://developers.facebook.com/docs/messenger-platform/send-messages/one-time-notification/#one-time-notif

To acquire one time notification token from the user:

```js
client.sendOneTimeNotifReqTemplate(USER_ID, {
  title: '<TITLE_TEXT>',
  payload: '<USER_DEFINED_PAYLOAD>',
});
```

To a send message with one time notification token:

```js
client.sendText({ oneTimeNotifToken: 'ONE_TIME_TOKEN' }, '<TEXT>');
```