### PR TITLE
messenger: use v6.0 graph api as default

### DIFF
--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -41,7 +41,7 @@ function handleError(err: AxiosError): void {
 export default class MessengerClient {
   static connect(
     accessTokenOrConfig: string | Types.ClientConfig,
-    version = '4.0'
+    version = '6.0'
   ): MessengerClient {
     return new MessengerClient(accessTokenOrConfig, version);
   }
@@ -60,7 +60,7 @@ export default class MessengerClient {
 
   constructor(
     accessTokenOrConfig: string | Types.ClientConfig,
-    version = '4.0'
+    version = '6.0'
   ) {
     let origin;
     let skipAppSecretProof;
@@ -75,7 +75,7 @@ export default class MessengerClient {
 
       this._appId = config.appId;
       this._appSecret = config.appSecret;
-      this._version = extractVersion(config.version || '4.0');
+      this._version = extractVersion(config.version || '6.0');
       this._onRequest = config.onRequest;
       origin = config.origin;
 

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.ts
@@ -30,7 +30,7 @@ describe('connect', () => {
 
       expect(axios.create).toBeCalledWith(
         expect.objectContaining({
-          baseURL: 'https://graph.facebook.com/v4.0/',
+          baseURL: 'https://graph.facebook.com/v6.0/',
           headers: { 'Content-Type': 'application/json' },
         })
       );
@@ -48,7 +48,7 @@ describe('connect', () => {
 
       expect(axios.create).toBeCalledWith(
         expect.objectContaining({
-          baseURL: 'https://graph.facebook.com/v4.0/',
+          baseURL: 'https://graph.facebook.com/v6.0/',
           headers: { 'Content-Type': 'application/json' },
         })
       );
@@ -108,7 +108,7 @@ describe('connect', () => {
 
     expect(axios.create).toBeCalledWith(
       expect.objectContaining({
-        baseURL: 'https://mydummytestserver.com/v4.0/',
+        baseURL: 'https://mydummytestserver.com/v6.0/',
         headers: { 'Content-Type': 'application/json' },
       })
     );
@@ -129,7 +129,7 @@ describe('constructor', () => {
 
       expect(axios.create).toBeCalledWith(
         expect.objectContaining({
-          baseURL: 'https://graph.facebook.com/v4.0/',
+          baseURL: 'https://graph.facebook.com/v6.0/',
           headers: { 'Content-Type': 'application/json' },
         })
       );
@@ -147,7 +147,7 @@ describe('constructor', () => {
 
       expect(axios.create).toBeCalledWith(
         expect.objectContaining({
-          baseURL: 'https://graph.facebook.com/v4.0/',
+          baseURL: 'https://graph.facebook.com/v6.0/',
           headers: { 'Content-Type': 'application/json' },
         })
       );
@@ -208,7 +208,7 @@ describe('constructor', () => {
 
     expect(axios.create).toBeCalledWith(
       expect.objectContaining({
-        baseURL: 'https://mydummytestserver.com/v4.0/',
+        baseURL: 'https://mydummytestserver.com/v6.0/',
         headers: { 'Content-Type': 'application/json' },
       })
     );
@@ -217,7 +217,7 @@ describe('constructor', () => {
 
 describe('#version', () => {
   it('should return version of graph api', () => {
-    expect(new MessengerClient(ACCESS_TOKEN).version).toEqual('4.0');
+    expect(new MessengerClient(ACCESS_TOKEN).version).toEqual('6.0');
     expect(new MessengerClient(ACCESS_TOKEN, 'v2.6').version).toEqual('2.6');
     expect(new MessengerClient(ACCESS_TOKEN, '2.6').version).toEqual('2.6');
     expect(() => {
@@ -226,7 +226,7 @@ describe('#version', () => {
     }).toThrow('Type of `version` must be string.');
 
     expect(new MessengerClient({ accessToken: ACCESS_TOKEN }).version).toEqual(
-      '4.0'
+      '6.0'
     );
     expect(
       new MessengerClient({ accessToken: ACCESS_TOKEN, version: 'v2.6' })
@@ -295,7 +295,7 @@ describe('#onRequest', () => {
 
     expect(onRequest).toBeCalledWith({
       method: 'post',
-      url: 'https://graph.facebook.com/v4.0/path',
+      url: 'https://graph.facebook.com/v6.0/path',
       body: {
         x: 1,
       },


### PR DESCRIPTION
Use `v6.0` instead of `v4.0` as default value.

https://developers.facebook.com/docs/graph-api/changelog/