### PR TITLE
line: use data domain to get media and menu content

### DIFF
--- a/packages/messaging-api-line/src/LineClient.js
+++ b/packages/messaging-api-line/src/LineClient.js
@@ -41,6 +41,7 @@ type ClientConfig = {
   accessToken: string,
   channelSecret: string,
   origin?: string,
+  dataOrigin?: string,
   onRequest?: Function,
 };
 
@@ -82,11 +83,14 @@ export default class LineClient {
 
   _axios: Axios;
 
+  _dataAxios: Axios;
+
   constructor(
     accessTokenOrConfig: string | ClientConfig,
     channelSecret: string
   ) {
     let origin;
+    let dataOrigin;
     if (accessTokenOrConfig && typeof accessTokenOrConfig === 'object') {
       const config = accessTokenOrConfig;
 
@@ -94,6 +98,7 @@ export default class LineClient {
       this._channelSecret = config.channelSecret;
       this._onRequest = config.onRequest || onRequest;
       origin = config.origin;
+      dataOrigin = config.dataOrigin;
     } else {
       this._accessToken = accessTokenOrConfig;
       this._channelSecret = channelSecret;
@@ -129,10 +134,44 @@ export default class LineClient {
       });
       return config;
     });
+
+    this._dataAxios = axios.create({
+      baseURL: `${dataOrigin || 'https://api-data.line.me'}/`,
+      headers: {
+        Authorization: `Bearer ${this._accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    this._dataAxios.interceptors.request.use(config => {
+      this._onRequest({
+        method: config.method,
+        url: urlJoin(config.baseURL, config.url),
+        headers: {
+          ...config.headers.common,
+          ...config.headers[config.method],
+          ...omit(config.headers, [
+            'common',
+            'get',
+            'post',
+            'put',
+            'patch',
+            'delete',
+            'head',
+          ]),
+        },
+        body: config.data,
+      });
+      return config;
+    });
   }
 
   get axios(): Axios {
     return this._axios;
+  }
+
+  get dataAxios(): Axios {
+    return this._dataAxios;
   }
 
   get accessToken(): string {
@@ -474,7 +513,7 @@ export default class LineClient {
    * https://developers.line.me/en/docs/messaging-api/reference/#get-content
    */
   retrieveMessageContent(messageId: string): Promise<Buffer> {
-    return this._axios
+    return this._dataAxios
       .get(`/v2/bot/message/${messageId}/content`, {
         responseType: 'arraybuffer',
       })
@@ -679,7 +718,7 @@ export default class LineClient {
       type && (type.mime === 'image/jpeg' || type.mime === 'image/png'),
       'Image must be `image/jpeg` or `image/png`'
     );
-    return this._axios
+    return this._dataAxios
       .post(`/v2/bot/richmenu/${richMenuId}/content`, image, {
         headers: {
           'Content-Type': type.mime,
@@ -689,7 +728,7 @@ export default class LineClient {
   }
 
   downloadRichMenuImage(richMenuId: string) {
-    return this._axios
+    return this._dataAxios
       .get(`/v2/bot/richmenu/${richMenuId}/content`, {
         responseType: 'arraybuffer',
       })

--- a/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.js
@@ -15,7 +15,8 @@ const headers = {
 const createMock = () => {
   const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
   const mock = new MockAdapter(client.axios);
-  return { client, mock };
+  const dataMock = new MockAdapter(client.dataAxios);
+  return { client, mock, dataMock };
 };
 
 describe('Rich Menu', () => {
@@ -224,11 +225,11 @@ describe('Rich Menu', () => {
 
   describe('#uploadRichMenuImage', () => {
     it('should call api', async () => {
-      const { client, mock } = createMock();
+      const { client, dataMock } = createMock();
 
       const reply = {};
 
-      mock.onPost('/v2/bot/richmenu/1/content').reply(200, reply);
+      dataMock.onPost('/v2/bot/richmenu/1/content').reply(200, reply);
 
       const buffer = await new Promise((resolve, reject) => {
         fs.readFile(path.join(__dirname, 'fixture.png'), (err, buf) => {
@@ -246,11 +247,11 @@ describe('Rich Menu', () => {
     });
 
     it('should call api', async () => {
-      const { client, mock } = createMock();
+      const { client, dataMock } = createMock();
 
       const reply = {};
 
-      mock.onPost('/v2/bot/richmenu/1/content').reply(200, reply);
+      dataMock.onPost('/v2/bot/richmenu/1/content').reply(200, reply);
 
       let error;
       try {
@@ -265,11 +266,11 @@ describe('Rich Menu', () => {
 
   describe('#downloadRichMenuImage', () => {
     it('should call api', async () => {
-      const { client, mock } = createMock();
+      const { client, dataMock } = createMock();
 
       const reply = Buffer.from('a content buffer');
 
-      mock.onGet('/v2/bot/richmenu/1/content').reply(200, reply);
+      dataMock.onGet('/v2/bot/richmenu/1/content').reply(200, reply);
 
       const res = await client.downloadRichMenuImage('1');
 

--- a/packages/messaging-api-line/src/__tests__/LineClient.spec.js
+++ b/packages/messaging-api-line/src/__tests__/LineClient.spec.js
@@ -14,19 +14,20 @@ const headers = {
 const createMock = () => {
   const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
   const mock = new MockAdapter(client.axios);
-  return { client, mock };
+  const dataMock = new MockAdapter(client.dataAxios);
+  return { client, mock, dataMock };
 };
 
 describe('Content', () => {
   describe('#retrieveMessageContent', () => {
     it('should call retrieveMessageContent api', async () => {
-      const { client, mock } = createMock();
+      const { client, dataMock } = createMock();
 
       const reply = Buffer.from('a content buffer');
 
       const MESSAGE_ID = '1234567890';
 
-      mock.onGet(`/v2/bot/message/${MESSAGE_ID}/content`).reply(200, reply);
+      dataMock.onGet(`/v2/bot/message/${MESSAGE_ID}/content`).reply(200, reply);
 
       const res = await client.retrieveMessageContent(MESSAGE_ID);
 


### PR DESCRIPTION
To avoid [the domain name breaking changes introduced by LINE](https://developers.line.biz/en/news/2019/11/08/domain-name-change/), port those changes into `v0.7.x` for Bottender `v0.15.x`.

> https://github.com/Yoctol/messaging-apis/pull/550
> Change the endpoint of api call in the following methods:
> - LineClient#getMessageContent
> - LineClient#uploadRichMenuImage
> - LineClient#downloadRichMenuImage