### PR TITLE
fix(LineType): allow quickReply and sender in Message type

### DIFF
--- a/packages/messaging-api-line/src/LineTypes.ts
+++ b/packages/messaging-api-line/src/LineTypes.ts
@@ -399,7 +399,7 @@ export type FlexMessage = {
   contents: FlexContainer;
 };
 
-export type Message =
+export type Message = (
   | TextMessage
   | ImageMessage
   | ImagemapMessage
@@ -408,7 +408,11 @@ export type Message =
   | LocationMessage
   | StickerMessage
   | TemplateMessage<Template>
-  | FlexMessage;
+  | FlexMessage
+) & {
+  quickReply?: QuickReply;
+  sender?: Sender;
+};
 
 type Area = {
   bounds: {


### PR DESCRIPTION
Allow `quickReply` and `sender` in `Message` type:

```js
await reply('<REPLY_TOKEN>', [
  {
    type: 'text',
    text: '<Text>',
    sender: {
      name: '<Sender>',
    }
  },
  {
    type: 'text',
    text: '<Text>',
    quickReply: {
      items: [
        // ....
      ]
    }
  }
]);
```