### PR TITLE
fix(Messengerbatch): set metadata to optional to match the behavior with MessengerClient

### DIFF
--- a/packages/messaging-api-messenger/src/MessengerBatch.ts
+++ b/packages/messaging-api-messenger/src/MessengerBatch.ts
@@ -327,7 +327,7 @@ function markSeen(
 function passThreadControl(
   recipientId: string,
   targetAppId: number,
-  metadata: string,
+  metadata?: string,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
@@ -347,15 +347,15 @@ function passThreadControl(
 
 function passThreadControlToPageInbox(
   recipientId: string,
-  metadata: string,
-  options: { accessToken?: string } = {}
+  metadata?: string,
+  options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ): Types.BatchItem {
   return passThreadControl(recipientId, 263902037430900, metadata, options);
 }
 
 function takeThreadControl(
   recipientId: string,
-  metadata: string,
+  metadata?: string,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);
@@ -374,7 +374,7 @@ function takeThreadControl(
 
 function requestThreadControl(
   recipientId: string,
-  metadata: string,
+  metadata?: string,
   options: { accessToken?: string } & Types.BatchRequestOptions = {}
 ): Types.BatchItem {
   const batchRequestOptions = pick(options, ['name', 'dependsOn']);


### PR DESCRIPTION
To fix errors in Bottender PR https://github.com/Yoctol/bottender/pull/764:

```
$ tsc --build tsconfig.build.json
packages/bottender/src/messenger/MessengerContext.ts:356:11 - error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.

356           metadata,
              ~~~~~~~~

packages/bottender/src/messenger/MessengerContext.ts:387:11 - error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.

387           metadata,
              ~~~~~~~~

packages/bottender/src/messenger/MessengerContext.ts:417:11 - error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.

417           metadata,
              ~~~~~~~~

packages/bottender/src/messenger/MessengerContext.ts:447:11 - error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.

447           metadata,
              ~~~~~~~~


Found 4 errors.
```

https://circleci.com/gh/Yoctol/bottender/13641?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link