### PR TITLE
fix: typo in slack types

### DIFF
--- a/packages/messaging-api-slack/src/SlackTypes.ts
+++ b/packages/messaging-api-slack/src/SlackTypes.ts
@@ -281,7 +281,7 @@ export type ActionsBlockElement =
   | DatepickerElement;
 
 export type ActionsBlock = {
-  type: 'action';
+  type: 'actions';
   elements: ActionsBlockElement[];
   blockId?: string;
 };


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/563929/83515547-22c6d980-a508-11ea-8b09-89aed2c95bdb.png)

references: https://api.slack.com/reference/block-kit/blocks#actions

