### PR TITLE
deprecated(connect): Use new instead of .connect factory method

### DIFF
--- a/examples/line/package.json
+++ b/examples/line/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "body-parser": "^1.18.1",
     "express": "^4.15.4",
-    "messaging-api-line": "^0.4.2"
+    "messaging-api-line": "latest"
   }
 }

--- a/examples/line/server.js
+++ b/examples/line/server.js
@@ -3,10 +3,10 @@ const { Line, LineClient } = require('messaging-api-line');
 
 const verifyMiddleware = require('./middleware/verify');
 
-const client = LineClient.connect(
-  process.env.ACCESS_TOKEN,
-  process.env.CHANNEL_SECRET
-);
+const client = new LineClient({
+  accessToken: process.env.ACCESS_TOKEN,
+  channelSecret: process.env.CHANNEL_SECRET,
+});
 
 const server = express();
 

--- a/examples/messenger/package.json
+++ b/examples/messenger/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "body-parser": "^1.18.1",
     "express": "^4.15.4",
-    "messaging-api-messenger": "^0.3.5"
+    "messaging-api-messenger": "latest"
   }
 }

--- a/examples/messenger/server.js
+++ b/examples/messenger/server.js
@@ -3,7 +3,9 @@ const bodyParser = require('body-parser');
 const { MessengerClient } = require('messaging-api-messenger');
 
 const server = express();
-const client = MessengerClient.connect(process.env.ACCESS_TOKEN);
+const client = new MessengerClient({
+  accessToken: process.env.ACCESS_TOKEN,
+});
 
 server.use(bodyParser.json());
 

--- a/packages/messaging-api-line/README.md
+++ b/packages/messaging-api-line/README.md
@@ -56,7 +56,7 @@ yarn add messaging-api-line
 const { LineClient } = require('messaging-api-line');
 
 // get accessToken and channelSecret from LINE developers website
-const client = LineClient.connect({
+const client = new LineClient({
   accessToken: ACCESS_TOKEN,
   channelSecret: CHANNEL_SECRET,
 });
@@ -2569,7 +2569,7 @@ client.deleteLiffApp(LIFF_ID);
 ```js
 const { LinePay } = require('messaging-api-line');
 
-const linePay = LinePay.connect({
+const linePay = new LinePay({
   channelId: CHANNEL_ID,
   channelSecret: CHANNEL_SECRET,
   sandbox: true, // default false
@@ -2840,7 +2840,7 @@ DEBUG=messaging-api-line
 If you want to use custom request logging function, just define your own `onRequest`:
 
 ```js
-const client = LineClient.connect({
+const client = new LineClient({
   accessToken: ACCESS_TOKEN,
   channelSecret: CHANNEL_SECRET,
   onRequest: ({ method, url, headers, body }) => {
@@ -2858,7 +2858,7 @@ To avoid sending requests to real LINE server, specify `origin` option when cons
 ```js
 const { LineClient } = require('messaging-api-line');
 
-const client = LineClient.connect({
+const client = new LineClient({
   accessToken: ACCESS_TOKEN,
   channelSecret: CHANNEL_SECRET,
   origin: 'https://mydummytestserver.com',

--- a/packages/messaging-api-line/src/LineClient.ts
+++ b/packages/messaging-api-line/src/LineClient.ts
@@ -40,10 +40,17 @@ function handleError(err: {
 }
 
 export default class LineClient {
+  /**
+   * @deprecated Use `new LineClient(...)` instead.
+   */
   static connect(
     accessTokenOrConfig: string | Types.ClientConfig,
     channelSecret?: string
   ): LineClient {
+    warning(
+      false,
+      '`LineClient.connect(...)` is deprecated. Use `new LineClient(...)` instead.'
+    );
     return new LineClient(accessTokenOrConfig, channelSecret);
   }
 

--- a/packages/messaging-api-line/src/LineNotify.ts
+++ b/packages/messaging-api-line/src/LineNotify.ts
@@ -2,6 +2,7 @@ import querystring from 'querystring';
 
 import AxiosError from 'axios-error';
 import axios, { AxiosInstance } from 'axios';
+import warning from 'warning';
 
 import * as Types from './LineTypes';
 
@@ -43,7 +44,14 @@ function throwWhenNotSuccess(res: {
  * LINE Notify
  */
 export default class LineNotify {
+  /**
+   * @deprecated Use `new LineNotify(...)` instead.
+   */
   static connect(config: Types.LineNotifyConfig): LineNotify {
+    warning(
+      false,
+      '`LineNotify.connect(...)` is deprecated. Use `new LineNotify(...)` instead.'
+    );
     return new LineNotify(config);
   }
 

--- a/packages/messaging-api-line/src/LinePay.ts
+++ b/packages/messaging-api-line/src/LinePay.ts
@@ -3,6 +3,7 @@ import querystring from 'querystring';
 import AxiosError from 'axios-error';
 import axios, { AxiosInstance } from 'axios';
 import invariant from 'invariant';
+import warning from 'warning';
 
 import * as Types from './LineTypes';
 
@@ -39,7 +40,14 @@ function throwWhenNotSuccess(res: {
 }
 
 export default class LinePay {
+  /**
+   * @deprecated Use `new LinePay(...)` instead.
+   */
   static connect(config: Types.LinePayConfig): LinePay {
+    warning(
+      false,
+      '`LineNotify.connect(...)` is deprecated. Use `new LineNotify(...)` instead.'
+    );
     return new LinePay(config);
   }
 

--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -64,13 +64,13 @@ yarn add messaging-api-messenger
 const { MessengerClient } = require('messaging-api-messenger');
 
 // get accessToken from facebook developers website
-const client = MessengerClient.connect(accessToken);
+const client = new MessengerClient(accessToken);
 ```
 
 You can specify version of Facebook Graph API using second argument:
 
 ```js
-const client = MessengerClient.connect({
+const client = new MessengerClient({
   accessToken: ACCESS_TOKEN,
   appId: APP_ID,
   appSecret: APP_SECRET,
@@ -85,7 +85,7 @@ If it is not specified, version `4.0` will be used as default.
 If `appSecret` is provided, `MessengerClient` will enable this feature automatically and include `appsecret_proof` in every Graph API requests. To skip it, set `skipAppSecretProof` to `true`:
 
 ```js
-const client = MessengerClient.connect({
+const client = new MessengerClient({
   accessToken: ACCESS_TOKEN,
   appId: APP_ID,
   appSecret: APP_SECRET,
@@ -3409,7 +3409,7 @@ DEBUG=messaging-api-messenger
 If you want to use custom request logging function, just define your own `onRequest`:
 
 ```js
-const client = MessengerClient.connect({
+const client = new MessengerClient({
   accessToken: ACCESS_TOKEN,
   onRequest: ({ method, url, headers, body }) => {
     /* */
@@ -3426,7 +3426,7 @@ To avoid sending requests to real Messenger server, specify `origin` option when
 ```js
 const { MessengerClient } = require('messaging-api-messenger');
 
-const client = MessengerClient.connect({
+const client = new MessengerClient({
   accessToken: ACCESS_TOKEN,
   origin: 'https://mydummytestserver.com',
 });

--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -11,6 +11,7 @@ import get from 'lodash/get';
 import invariant from 'invariant';
 import isPlainObject from 'lodash/isPlainObject';
 import omit from 'lodash/omit';
+import warning from 'warning';
 import {
   OnRequestFunction,
   camelcaseKeysDeep,
@@ -38,10 +39,17 @@ function handleError(err: AxiosError): never {
 }
 
 export default class MessengerClient {
+  /**
+   * @deprecated Use `new MessengerClient(...)` instead.
+   */
   static connect(
     accessTokenOrConfig: string | Types.ClientConfig,
     version = '6.0'
   ): MessengerClient {
+    warning(
+      false,
+      '`MessengerClient.connect(...)` is deprecated. Use `new MessengerClient(...)` instead.'
+    );
     return new MessengerClient(accessTokenOrConfig, version);
   }
 

--- a/packages/messaging-api-slack/README.md
+++ b/packages/messaging-api-slack/README.md
@@ -41,7 +41,7 @@ const { SlackOAuthClient } = require('messaging-api-slack');
 
 // get access token by setup OAuth & Permissions function to your app.
 // https://api.slack.com/docs/oauth
-const client = SlackOAuthClient.connect(
+const client = new SlackOAuthClient(
   'xoxb-000000000000-xxxxxxxxxxxxxxxxxxxxxxxx'
 );
 ```
@@ -442,7 +442,7 @@ const { SlackWebhookClient } = require('messaging-api-slack');
 
 // get webhook URL by adding a Incoming Webhook integration to your team.
 // https://my.slack.com/services/new/incoming-webhook/
-const client = SlackWebhookClient.connect(
+const client = new SlackWebhookClient(
   'https://hooks.slack.com/services/XXXXXXXX/YYYYYYYY/zzzzzZZZZZ'
 );
 ```
@@ -567,7 +567,7 @@ If you want to use custom request logging function, just define your own `onRequ
 
 ```js
 // for SlackOAuthClient
-const client = SlackOAuthClient.connect({
+const client = new SlackOAuthClient({
   accessToken: ACCESS_TOKEN,
   onRequest: ({ method, url, headers, body }) => {
     /* */
@@ -575,7 +575,7 @@ const client = SlackOAuthClient.connect({
 });
 
 // for SlackWebhookClient
-const client = SlackWebhookClient.connect({
+const client = new SlackWebhookClient({
   url: URL,
   onRequest: ({ method, url, headers, body }) => {
     /* */
@@ -592,7 +592,7 @@ To avoid sending requests to real Slack server, specify `origin` option when con
 ```js
 const { SlackOAuthClient } = require('messaging-api-slack');
 
-const client = SlackOAuthClient.connect({
+const client = new SlackOAuthClient({
   accessToken: ACCESS_TOKEN,
   origin: 'https://mydummytestserver.com',
 });

--- a/packages/messaging-api-slack/src/SlackOAuthClient.ts
+++ b/packages/messaging-api-slack/src/SlackOAuthClient.ts
@@ -80,9 +80,16 @@ export default class SlackOAuthClient {
     ) => Promise<Types.OAuthAPIResponse>;
   };
 
+  /**
+   * @deprecated Use `new SlackOAuthClient(...)` instead.
+   */
   static connect(
     accessTokenOrConfig: string | Types.ClientConfig
   ): SlackOAuthClient {
+    warning(
+      false,
+      '`SlackOAuthClient.connect(...)` is deprecated. Use `new SlackOAuthClient(...)` instead.'
+    );
     return new SlackOAuthClient(accessTokenOrConfig);
   }
 

--- a/packages/messaging-api-slack/src/SlackWebhookClient.ts
+++ b/packages/messaging-api-slack/src/SlackWebhookClient.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import warning from 'warning';
 import {
   OnRequestFunction,
   createRequestInterceptor,
@@ -17,7 +18,14 @@ export default class SlackWebhookClient {
 
   _onRequest: OnRequestFunction | undefined;
 
+  /**
+   * @deprecated Use `new SlackWebhookClient(...)` instead.
+   */
   static connect(urlOrConfig: string | ClientConfig): SlackWebhookClient {
+    warning(
+      false,
+      '`SlackWebhookClient.connect(...)` is deprecated. Use `new SlackWebhookClient(...)` instead.'
+    );
     return new SlackWebhookClient(urlOrConfig);
   }
 

--- a/packages/messaging-api-telegram/README.md
+++ b/packages/messaging-api-telegram/README.md
@@ -43,7 +43,7 @@ yarn add messaging-api-telegram
 const { TelegramClient } = require('messaging-api-telegram');
 
 // get accessToken from telegram [@BotFather](https://telegram.me/BotFather)
-const client = TelegramClient.connect('12345678:AaBbCcDdwhatever');
+const client = new TelegramClient('12345678:AaBbCcDdwhatever');
 ```
 
 ### Error Handling
@@ -1271,7 +1271,7 @@ DEBUG=messaging-api-telegram
 If you want to use custom request logging function, just define your own `onRequest`:
 
 ```js
-const client = TelegramClient.connect({
+const client = new TelegramClient({
   accessToken: ACCESS_TOKEN,
   onRequest: ({ method, url, headers, body }) => {
     /* */
@@ -1288,7 +1288,7 @@ To avoid sending requests to real Telegram server, specify `origin` option when 
 ```js
 const { TelegramClient } = require('messaging-api-telegram');
 
-const client = TelegramClient.connect({
+const client = new TelegramClient({
   accessToken: ACCESS_TOKEN,
   origin: 'https://mydummytestserver.com',
 });

--- a/packages/messaging-api-telegram/package.json
+++ b/packages/messaging-api-telegram/package.json
@@ -13,7 +13,8 @@
     "axios": "^0.19.2",
     "axios-error": "file:../axios-error",
     "lodash": "^4.17.15",
-    "messaging-api-common": "file:../messaging-api-common"
+    "messaging-api-common": "file:../messaging-api-common",
+    "warning": "^4.0.3"
   },
   "keywords": [
     "bot",

--- a/packages/messaging-api-telegram/src/TelegramClient.ts
+++ b/packages/messaging-api-telegram/src/TelegramClient.ts
@@ -5,6 +5,7 @@ import axios, { AxiosInstance } from 'axios';
 import difference from 'lodash/difference';
 import isPlainObject from 'lodash/isPlainObject';
 import pick from 'lodash/pick';
+import warning from 'warning';
 import {
   OnRequestFunction,
   camelcaseKeysDeep,
@@ -16,9 +17,16 @@ import {
 import * as Types from './TelegramTypes';
 
 export default class TelegramClient {
+  /**
+   * @deprecated Use `new TelegramClient(...)` instead.
+   */
   static connect(
     accessTokenOrConfig: string | Types.ClientConfig
   ): TelegramClient {
+    warning(
+      false,
+      '`TelegramClient.connect(...)` is deprecated. Use `new TelegramClient(...)` instead.'
+    );
     return new TelegramClient(accessTokenOrConfig);
   }
 

--- a/packages/messaging-api-viber/README.md
+++ b/packages/messaging-api-viber/README.md
@@ -41,7 +41,7 @@ yarn add messaging-api-viber
 const { ViberClient } = require('messaging-api-viber');
 
 // get authToken from the "edit info" screen of your Public Account.
-const client = ViberClient.connect(authToken);
+const client = new ViberClient(authToken);
 ```
 
 ### Error Handling
@@ -655,7 +655,7 @@ DEBUG=messaging-api-viber
 If you want to use custom request logging function, just define your own `onRequest`:
 
 ```js
-const client = ViberClient.connect({
+const client = new ViberClient({
   accessToken: ACCESS_TOKEN,
   onRequest: ({ method, url, headers, body }) => {
     /* */
@@ -672,7 +672,7 @@ To avoid sending requests to real Viber server, specify `origin` option when con
 ```js
 const { ViberClient } = require('messaging-api-viber');
 
-const client = ViberClient.connect({
+const client = new ViberClient({
   accessToken: ACCESS_TOKEN,
   origin: 'https://mydummytestserver.com',
 });

--- a/packages/messaging-api-viber/package.json
+++ b/packages/messaging-api-viber/package.json
@@ -13,7 +13,8 @@
     "axios": "^0.19.2",
     "axios-error": "file:../axios-error",
     "lodash": "^4.17.15",
-    "messaging-api-common": "file:../messaging-api-common"
+    "messaging-api-common": "file:../messaging-api-common",
+    "warning": "^4.0.3"
   },
   "keywords": [
     "bot",

--- a/packages/messaging-api-viber/src/ViberClient.ts
+++ b/packages/messaging-api-viber/src/ViberClient.ts
@@ -2,6 +2,7 @@
 
 import AxiosError from 'axios-error';
 import axios, { AxiosInstance } from 'axios';
+import warning from 'warning';
 import {
   OnRequestFunction,
   camelcaseKeysDeep,
@@ -32,10 +33,17 @@ function transformMessageCase(message: Types.Message): any {
  * https://developers.viber.com/docs/api/rest-bot-api/#viber-rest-api
  */
 export default class ViberClient {
+  /**
+   * @deprecated Use `new ViberClient(...)` instead.
+   */
   static connect(
     accessTokenOrConfig: string | Types.ClientConfig,
     sender?: Types.Sender
   ): ViberClient {
+    warning(
+      false,
+      '`ViberClient.connect(...)` is deprecated. Use `new ViberClient(...)` instead.'
+    );
     return new ViberClient(accessTokenOrConfig, sender);
   }
 

--- a/packages/messaging-api-wechat/README.md
+++ b/packages/messaging-api-wechat/README.md
@@ -34,7 +34,7 @@ yarn add messaging-api-wechat
 const { WechatClient } = require('messaging-api-wechat');
 
 // get appId, appSecret from「微信公众平台-开发-基本配置」page
-const client = WechatClient.connect({
+const client = new WechatClient({
   appId: APP_ID,
   appSecret: APP_SECRET,
 });
@@ -265,7 +265,7 @@ DEBUG=messaging-api-wechat
 If you want to use custom request logging function, just define your own `onRequest`:
 
 ```js
-const client = WechatClient.connect({
+const client = new WechatClient({
   appId: APP_ID,
   appSecret: APP_SECRET,
   onRequest: ({ method, url, headers, body }) => {
@@ -283,7 +283,7 @@ To avoid sending requests to real WeChat server, specify `origin` option when co
 ```js
 const { WechatClient } = require('messaging-api-wechat');
 
-const client = WechatClient.connect({
+const client = new WechatClient({
   appId: APP_ID,
   appSecret: APP_SECRET,
   origin: 'https://mydummytestserver.com',

--- a/packages/messaging-api-wechat/package.json
+++ b/packages/messaging-api-wechat/package.json
@@ -14,7 +14,8 @@
     "axios-error": "file:../axios-error",
     "form-data": "^3.0.0",
     "lodash": "^4.17.15",
-    "messaging-api-common": "file:../messaging-api-common"
+    "messaging-api-common": "file:../messaging-api-common",
+    "warning": "^4.0.3"
   },
   "keywords": [
     "bot",

--- a/packages/messaging-api-wechat/src/WechatClient.ts
+++ b/packages/messaging-api-wechat/src/WechatClient.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import AxiosError from 'axios-error';
 import FormData from 'form-data';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import warning from 'warning';
 import {
   OnRequestFunction,
   camelcaseKeys,
@@ -25,10 +26,17 @@ function throwErrorIfAny(response: AxiosResponse): AxiosResponse | never {
 }
 
 export default class WechatClient {
+  /**
+   * @deprecated Use `new WechatClient(...)` instead.
+   */
   static connect(
     appIdOrClientConfig: string | Types.ClientConfig,
     appSecret: string
   ): WechatClient {
+    warning(
+      false,
+      '`WechatClient.connect(...)` is deprecated. Use `new WechatClient(...)` instead.'
+    );
     return new WechatClient(appIdOrClientConfig, appSecret);
   }
 


### PR DESCRIPTION
We add those factories for testing at the very beginning, but it's not needed anymore. And the name `connect` sometimes gets people confused (https://github.com/Yoctol/messaging-apis/issues/541).

So this PR adds warnings in v1 and we will safely remove it in v2.