### PR TITLE
pkg(facebook-batch): move facebook-batch to this monorepo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
       node: {
         extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
+      typescript: {},
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-config-yoctol-base": "^0.23.1",
+    "eslint-import-resolver-typescript": "^2.0.0",
     "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
@@ -62,7 +63,7 @@
     "typescript": "^3.9.5"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "husky": {
     "hooks": {

--- a/packages/facebook-batch/README.md
+++ b/packages/facebook-batch/README.md
@@ -1,0 +1,87 @@
+# facebook-batch
+
+> Gracefully batching facebook requests.
+
+This module is based on the approach described in [Making Batch Requests](https://developers.facebook.com/docs/graph-api/making-multiple-requests/).
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+
+## Installation
+
+```sh
+npm i --save facebook-batch
+```
+
+or
+
+```sh
+yarn add facebook-batch
+```
+
+<br />
+
+## Usage
+
+```js
+const { MessengerClient, MessengerBatch } = require('messaging-api-messenger');
+const { FacebookBatchQueue } = require('facebook-batch');
+
+const client = MessengerClient.connect({
+  accessToken: ACCESS_TOKEN,
+});
+
+const queue = new FacebookBatchQueue(client);
+
+(async () => {
+  await queue.push(
+    MessengerBatch.sendText('psid', 'hello!');
+  );
+
+  await queue.push(
+    MessengerBatch.sendMessage('psid', {
+      attachment: {
+        type: 'image',
+        payload: {
+          url:
+            'https://cdn.free.com.tw/blog/wp-content/uploads/2014/08/Placekitten480-g.jpg',
+        },
+      },
+    })
+  );
+
+  const profile = await queue.push(MessengerBatch.getUserProfile('psid'));
+
+
+  console.log(profile);
+
+  queue.stop();
+})();
+```
+
+Retry for error: `(#613) Calls to this api have exceeded the rate limit.`.
+
+```js
+const { FacebookBatchQueue, isError613 } = require('facebook-batch');
+
+const queue = new FacebookBatchQueue(client, {
+  shouldRetry: isError613,
+  retryTimes: 2,
+});
+```
+
+## Options
+
+### delay
+
+Default: `1000`.
+
+### retryTimes
+
+Default: `0`.
+
+### shouldRetry
+
+Default: `() => true`.

--- a/packages/facebook-batch/package.json
+++ b/packages/facebook-batch/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "facebook-batch",
+  "description": "Gracefully batching facebook requests.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Yoctol/messaging-apis.git"
+  },
+  "version": "1.0.0-beta.25",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@types/invariant": "^2.2.33",
+    "invariant": "^2.2.4",
+    "messaging-api-messenger": "file:../messaging-api-messenger",
+    "type-fest": "^0.15.1"
+  },
+  "keywords": [
+    "batch",
+    "bottender",
+    "facebook",
+    "messaging-apis",
+    "messenger"
+  ],
+  "engines": {
+    "node": ">=10"
+  }
+}

--- a/packages/facebook-batch/src/BatchRequestError.ts
+++ b/packages/facebook-batch/src/BatchRequestError.ts
@@ -22,11 +22,11 @@ Error Message - Batch Request Error
 Request -
 
 ${this.request.method.toUpperCase()} ${this.request.relativeUrl}
-${this.request.body || ''}
+${JSON.stringify(this.request.body, null, 2) || ''}
 
 Response -
 ${this.response.code}
-${this.response.body || ''}
+${JSON.stringify(this.response.body, null, 2) || ''}
     `;
   }
 }

--- a/packages/facebook-batch/src/BatchRequestError.ts
+++ b/packages/facebook-batch/src/BatchRequestError.ts
@@ -1,0 +1,32 @@
+import { BatchRequest, BatchRequestErrorInfo, BatchResponse } from './types';
+import { getErrorMessage } from './utils';
+
+export default class BatchRequestError extends Error {
+  request: BatchRequest;
+
+  response: BatchResponse;
+
+  constructor({ request, response }: BatchRequestErrorInfo) {
+    const message = getErrorMessage({ request, response });
+
+    super(`Batch Request Error - ${message}`);
+
+    this.request = request;
+    this.response = response;
+  }
+
+  inspect(): string {
+    return `
+Error Message - Batch Request Error
+
+Request -
+
+${this.request.method.toUpperCase()} ${this.request.relativeUrl}
+${this.request.body || ''}
+
+Response -
+${this.response.code}
+${this.response.body || ''}
+    `;
+  }
+}

--- a/packages/facebook-batch/src/FacebookBatchQueue.ts
+++ b/packages/facebook-batch/src/FacebookBatchQueue.ts
@@ -1,0 +1,105 @@
+import invariant from 'invariant';
+import { JsonObject } from 'type-fest';
+import { MessengerClient } from 'messaging-api-messenger';
+
+import BatchRequestError from './BatchRequestError';
+import { BatchRequest, BatchRequestErrorInfo, QueueItem } from './types';
+
+const MAX_BATCH_SIZE = 50;
+
+const alwaysTrue = (): true => true;
+
+export default class FacebookBatchQueue {
+  _client: MessengerClient;
+
+  _queue: QueueItem[];
+
+  _delay: number;
+
+  _shouldRetry: (err: BatchRequestErrorInfo) => boolean;
+
+  _retryTimes: number;
+
+  _timeout: NodeJS.Timeout;
+
+  constructor(
+    client: MessengerClient,
+    options: {
+      delay?: number;
+      shouldRetry?: (err: BatchRequestErrorInfo) => boolean;
+      retryTimes?: number;
+    } = {}
+  ) {
+    invariant(
+      client,
+      'Must provide a MessengerClient or FacebookClient instance'
+    );
+
+    this._client = client;
+    this._queue = [];
+    this._delay = options.delay ?? 1000;
+    this._shouldRetry = options.shouldRetry ?? alwaysTrue;
+    this._retryTimes = options.retryTimes ?? 0;
+
+    this._timeout = setTimeout(() => this.flush(), this._delay);
+  }
+
+  get queue(): QueueItem[] {
+    return this._queue;
+  }
+
+  push(request: BatchRequest): Promise<JsonObject> {
+    const promise = new Promise((resolve, reject) => {
+      this._queue.push({ request, resolve, reject });
+    });
+
+    if (this._queue.length >= MAX_BATCH_SIZE) {
+      this.flush();
+    }
+
+    return promise as Promise<JsonObject>;
+  }
+
+  async flush(): Promise<void> {
+    const items = this._queue.splice(0, MAX_BATCH_SIZE);
+
+    clearTimeout(this._timeout);
+    this._timeout = setTimeout(() => this.flush(), this._delay);
+
+    if (items.length < 1) return;
+
+    try {
+      const responses = await this._client.sendBatch(
+        items.map((item) => item.request)
+      );
+
+      items.forEach(({ request, resolve, reject, retry = 0 }, i) => {
+        const response = responses[i];
+        if (response.code === 200) {
+          resolve(JSON.parse(response.body));
+          return;
+        }
+
+        const err: BatchRequestErrorInfo = { response, request };
+
+        if (retry < this._retryTimes && this._shouldRetry(err)) {
+          this._queue.push({ request, resolve, reject, retry: retry + 1 });
+        } else {
+          reject(new BatchRequestError(err));
+        }
+      });
+    } catch (err) {
+      items.forEach(({ request, resolve, reject, retry = 0 }) => {
+        if (retry < this._retryTimes && this._shouldRetry(err)) {
+          this._queue.push({ request, resolve, reject, retry: retry + 1 });
+        } else {
+          reject(err);
+        }
+      });
+    }
+  }
+
+  stop(): void {
+    clearTimeout(this._timeout);
+  }
+}

--- a/packages/facebook-batch/src/__tests__/BatchRequestError.spec.ts
+++ b/packages/facebook-batch/src/__tests__/BatchRequestError.spec.ts
@@ -1,20 +1,28 @@
 import BatchRequestError from '../BatchRequestError';
-import { BatchRequest, BatchResponse } from '../types';
+import { BatchErrorResponse, BatchRequest } from '../types';
 
 it('should work', async () => {
   const request: BatchRequest = {
     method: 'POST',
     relativeUrl: 'me/feed',
-    body: 'message=Test status update&amp;link=http://developers.facebook.com/',
+    body: {
+      message: 'Test status update',
+      link: 'http://developers.facebook.com/',
+    },
   };
-  const response: BatchResponse = {
+  const response: BatchErrorResponse = {
     code: 403,
     headers: [
       { name: 'WWW-Authenticate', value: 'OAuth…' },
       { name: 'Content-Type', value: 'text/javascript; charset=UTF-8' },
     ],
-    body:
-      '{"error":{"type":"OAuthException","message": "Invalid parameter","code": 100}}',
+    body: {
+      error: {
+        type: 'OAuthException',
+        message: 'Invalid parameter',
+        code: 100,
+      },
+    },
   };
   const error = new BatchRequestError({ request, response });
 
@@ -25,16 +33,24 @@ it('should have better error message', async () => {
   const request: BatchRequest = {
     method: 'POST',
     relativeUrl: 'me/feed',
-    body: 'message=Test status update&amp;link=http://developers.facebook.com/',
+    body: {
+      message: 'Test status update',
+      link: 'http://developers.facebook.com/',
+    },
   };
-  const response: BatchResponse = {
+  const response: BatchErrorResponse = {
     code: 403,
     headers: [
       { name: 'WWW-Authenticate', value: 'OAuth…' },
       { name: 'Content-Type', value: 'text/javascript; charset=UTF-8' },
     ],
-    body:
-      '{"error":{"type":"OAuthException","message": "Invalid parameter","code": 100}}',
+    body: {
+      error: {
+        type: 'OAuthException',
+        message: 'Invalid parameter',
+        code: 100,
+      },
+    },
   };
   const error = new BatchRequestError({ request, response });
 

--- a/packages/facebook-batch/src/__tests__/BatchRequestError.spec.ts
+++ b/packages/facebook-batch/src/__tests__/BatchRequestError.spec.ts
@@ -1,0 +1,42 @@
+import BatchRequestError from '../BatchRequestError';
+import { BatchRequest, BatchResponse } from '../types';
+
+it('should work', async () => {
+  const request: BatchRequest = {
+    method: 'POST',
+    relativeUrl: 'me/feed',
+    body: 'message=Test status update&amp;link=http://developers.facebook.com/',
+  };
+  const response: BatchResponse = {
+    code: 403,
+    headers: [
+      { name: 'WWW-Authenticate', value: 'OAuth…' },
+      { name: 'Content-Type', value: 'text/javascript; charset=UTF-8' },
+    ],
+    body:
+      '{"error":{"type":"OAuthException","message": "Invalid parameter","code": 100}}',
+  };
+  const error = new BatchRequestError({ request, response });
+
+  expect(error.inspect()).toMatchSnapshot();
+});
+
+it('should have better error message', async () => {
+  const request: BatchRequest = {
+    method: 'POST',
+    relativeUrl: 'me/feed',
+    body: 'message=Test status update&amp;link=http://developers.facebook.com/',
+  };
+  const response: BatchResponse = {
+    code: 403,
+    headers: [
+      { name: 'WWW-Authenticate', value: 'OAuth…' },
+      { name: 'Content-Type', value: 'text/javascript; charset=UTF-8' },
+    ],
+    body:
+      '{"error":{"type":"OAuthException","message": "Invalid parameter","code": 100}}',
+  };
+  const error = new BatchRequestError({ request, response });
+
+  expect(error.message).toEqual('Batch Request Error - Invalid parameter');
+});

--- a/packages/facebook-batch/src/__tests__/FacebookBatchQueue.spec.ts
+++ b/packages/facebook-batch/src/__tests__/FacebookBatchQueue.spec.ts
@@ -1,0 +1,389 @@
+import { MessengerClient } from 'messaging-api-messenger';
+import { mocked } from 'ts-jest/utils';
+
+import BatchRequestError from '../BatchRequestError';
+import FacebookBatchQueue from '../FacebookBatchQueue';
+import { isError613 } from '..';
+
+jest.mock('messaging-api-messenger');
+
+const { MessengerBatch } = jest.requireActual('messaging-api-messenger');
+
+const image = {
+  attachment: {
+    type: 'image',
+    payload: {
+      url:
+        'https://cdn.free.com.tw/blog/wp-content/uploads/2014/08/Placekitten480-g.jpg',
+    },
+  },
+};
+
+let queue: FacebookBatchQueue;
+
+function setup(
+  options = {}
+): {
+  client: MessengerClient;
+  timeout: NodeJS.Timeout;
+} {
+  // https://github.com/nodejs/node/blob/e1ad548cd4bfb996ea925584542f30c85aa3dfa1/lib/internal/timers.js#L202-L231
+  const timeout: NodeJS.Timeout = {
+    hasRef: () => true,
+    refresh: () => timeout,
+    ref: () => timeout,
+    unref: () => timeout,
+  };
+  mocked(setTimeout).mockReturnValue(timeout);
+
+  const client = new MessengerClient({
+    accessToken: 'ACCESS_TOKEN',
+    appSecret: 'APP_SECRET',
+  });
+  queue = new FacebookBatchQueue(client, options);
+
+  return {
+    client,
+    timeout,
+  };
+}
+
+afterEach(() => {
+  queue.stop();
+});
+
+it('should push psid and messages to queue', () => {
+  setup();
+
+  queue.push(MessengerBatch.sendMessage('1412611362105802', image));
+
+  expect(queue.queue).toHaveLength(1);
+});
+
+it('should flush when length >= 50', async () => {
+  const { client } = setup();
+
+  const responses = Array(50)
+    .fill(0)
+    .map(() => ({
+      code: 200,
+      body: '{"data": []}',
+    }));
+
+  mocked(client.sendBatch).mockResolvedValue(responses);
+
+  for (let i = 0; i < 49; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    queue.push(MessengerBatch.sendText('1412611362105802', 'hello'));
+  }
+
+  queue.push(MessengerBatch.sendMessage('1412611362105802', image));
+
+  expect(client.sendBatch).toHaveBeenCalledTimes(1);
+  expect(mocked(client.sendBatch).mock.calls[0][0]).toHaveLength(50);
+
+  expect(mocked(client.sendBatch).mock.calls[0][0][49]).toEqual({
+    body: {
+      message: {
+        attachment: {
+          payload: {
+            url:
+              'https://cdn.free.com.tw/blog/wp-content/uploads/2014/08/Placekitten480-g.jpg',
+          },
+          type: 'image',
+        },
+      },
+      messagingType: 'UPDATE',
+      recipient: { id: '1412611362105802' },
+    },
+    method: 'POST',
+    relativeUrl: 'me/messages',
+  });
+
+  expect(queue.queue).toHaveLength(0);
+});
+
+it('should flush with 1000 timeout', async () => {
+  const { client } = setup();
+
+  const responses = [
+    {
+      code: 200,
+      body: '{"data": []}',
+    },
+  ];
+
+  mocked(client.sendBatch).mockResolvedValue(responses);
+
+  expect(setTimeout).toHaveBeenCalledTimes(1);
+  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+
+  queue.push(MessengerBatch.sendMessage('1412611362105802', image));
+
+  expect(queue.queue).toHaveLength(1);
+
+  const fn = mocked(setTimeout).mock.calls[0][0];
+
+  await fn();
+
+  expect(client.sendBatch).toHaveBeenCalledTimes(1);
+  expect(mocked(client.sendBatch).mock.calls[0][0]).toEqual([
+    {
+      body: {
+        message: {
+          attachment: {
+            payload: {
+              url:
+                'https://cdn.free.com.tw/blog/wp-content/uploads/2014/08/Placekitten480-g.jpg',
+            },
+            type: 'image',
+          },
+        },
+        messagingType: 'UPDATE',
+        recipient: { id: '1412611362105802' },
+      },
+      method: 'POST',
+      relativeUrl: 'me/messages',
+    },
+  ]);
+});
+
+it('should not send batch when with empty array', async () => {
+  const { client } = setup();
+
+  const responses = [
+    {
+      code: 200,
+      body: '{"data": []}',
+    },
+  ];
+
+  mocked(client.sendBatch).mockResolvedValue(responses);
+
+  expect(setTimeout).toHaveBeenCalledTimes(1);
+  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+
+  const fn = mocked(setTimeout).mock.calls[0][0];
+
+  await fn();
+
+  expect(client.sendBatch).not.toBeCalled();
+});
+
+it('should reset timeout when flush', async () => {
+  const { client, timeout } = setup();
+
+  const responses = Array(50)
+    .fill(0)
+    .map(() => ({
+      code: 200,
+      body: '{"data": []}',
+    }));
+
+  mocked(client.sendBatch).mockResolvedValue(responses);
+
+  expect(setTimeout).toHaveBeenCalledTimes(1);
+  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+
+  for (let i = 0; i < 49; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    queue.push(MessengerBatch.sendText('1412611362105802', 'hello'));
+  }
+
+  queue.push(MessengerBatch.sendMessage('1412611362105802', image));
+
+  expect(clearTimeout).toHaveBeenCalledTimes(1);
+  expect(clearTimeout).toHaveBeenLastCalledWith(timeout);
+  expect(setTimeout).toHaveBeenCalledTimes(2);
+  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+});
+
+it('should throw request and response', async () => {
+  const { client } = setup();
+
+  const responses = [
+    {
+      code: 400,
+      body:
+        '{"error": {"message": "(#100) Param recipient[id] must be a valid ID string (e.g., \\"123\\")"} }',
+    },
+  ];
+
+  mocked(client.sendBatch).mockReturnValue(Promise.resolve(responses));
+
+  let error: BatchRequestError | undefined;
+
+  queue
+    .push(MessengerBatch.sendMessage('1412611362105802', image))
+    .catch((err) => {
+      error = err;
+    });
+
+  expect(setTimeout).toHaveBeenCalledTimes(1);
+  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+
+  const fn = mocked(setTimeout).mock.calls[0][0];
+
+  await fn();
+
+  expect(error).toBeDefined();
+  expect(error!.request).toEqual({
+    body: {
+      message: {
+        attachment: {
+          payload: {
+            url:
+              'https://cdn.free.com.tw/blog/wp-content/uploads/2014/08/Placekitten480-g.jpg',
+          },
+          type: 'image',
+        },
+      },
+      messagingType: 'UPDATE',
+      recipient: { id: '1412611362105802' },
+    },
+    method: 'POST',
+    relativeUrl: 'me/messages',
+  });
+  expect(error!.response).toEqual({
+    body:
+      '{"error": {"message": "(#100) Param recipient[id] must be a valid ID string (e.g., \\"123\\")"} }',
+    code: 400,
+  });
+});
+
+it('should support delay option', async () => {
+  const { client } = setup({ delay: 500 });
+
+  const responses = [
+    {
+      code: 200,
+      body: '{"data": []}',
+    },
+  ];
+
+  mocked(client.sendBatch).mockResolvedValue(responses);
+
+  expect(setTimeout).toHaveBeenCalledTimes(1);
+  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 500);
+});
+
+it('should support retryTimes option', async () => {
+  const { client } = setup({ retryTimes: 3 });
+
+  const responses = [
+    {
+      code: 400,
+      body:
+        '{"error": {"message": "(#100) Param recipient[id] must be a valid ID string (e.g., \\"123\\")"} }',
+    },
+  ];
+
+  mocked(client.sendBatch).mockResolvedValue(responses);
+
+  let error: BatchRequestError | undefined;
+  queue
+    .push(MessengerBatch.sendMessage('1412611362105802', image))
+    .catch((err) => {
+      error = err;
+    });
+
+  const fn = mocked(setTimeout).mock.calls[0][0];
+
+  await fn();
+  expect(error).not.toBeDefined();
+
+  await fn();
+  expect(error).not.toBeDefined();
+
+  await fn();
+  expect(error).not.toBeDefined();
+
+  await fn();
+  expect(error).toBeDefined();
+});
+
+it('should support shouldRetry option', async () => {
+  const { client } = setup({
+    retryTimes: 1,
+    shouldRetry: isError613,
+  });
+
+  const responses = [
+    {
+      code: 400,
+      body:
+        '{"error": {"message": "(#100) Param recipient[id] must be a valid ID string (e.g., \\"123\\")"} }',
+    },
+    {
+      code: 400,
+      body:
+        '{"error": {"message": "(#613) Calls to this api have exceeded the rate limit."} }',
+    },
+  ];
+
+  mocked(client.sendBatch).mockResolvedValue(responses);
+
+  let error1: BatchRequestError | undefined;
+  const request1 = MessengerBatch.sendMessage('1412611362105802', image);
+
+  queue.push(request1).catch((err: BatchRequestError) => {
+    error1 = err;
+  });
+
+  let error2: BatchRequestError | undefined;
+  const request2 = MessengerBatch.sendMessage('1412611362105802', image);
+
+  queue.push(request2).catch((err: BatchRequestError) => {
+    error2 = err;
+  });
+
+  expect(queue.queue).toHaveLength(2);
+
+  const fn = mocked(setTimeout).mock.calls[0][0];
+
+  await fn();
+  expect(queue.queue).toHaveLength(1);
+  expect(client.sendBatch).toHaveBeenCalledTimes(1);
+  expect(mocked(client.sendBatch).mock.calls[0][0]).toHaveLength(2);
+  expect(mocked(client.sendBatch).mock.calls[0][0][0]).toBe(request1);
+  expect(mocked(client.sendBatch).mock.calls[0][0][1]).toBe(request2);
+  expect(error1).toBeDefined();
+  expect(error2).not.toBeDefined();
+
+  await fn();
+  expect(queue.queue).toHaveLength(0);
+  expect(client.sendBatch).toHaveBeenCalledTimes(2);
+  expect(mocked(client.sendBatch).mock.calls[1][0]).toHaveLength(1);
+  expect(mocked(client.sendBatch).mock.calls[1][0][0]).toBe(request2);
+
+  expect(error2).toBeDefined();
+});
+
+it('should reject every promise when call batch failed', async () => {
+  const { client } = setup();
+
+  mocked(client.sendBatch).mockImplementation(() => {
+    throw new Error('boom');
+  });
+
+  let error1: BatchRequestError | undefined;
+  const request1 = MessengerBatch.sendMessage('1412611362105802', image);
+
+  queue.push(request1).catch((err: BatchRequestError) => {
+    error1 = err;
+  });
+
+  let error2: BatchRequestError | undefined;
+  const request2 = MessengerBatch.sendMessage('1412611362105802', image);
+
+  queue.push(request2).catch((err: BatchRequestError) => {
+    error2 = err;
+  });
+
+  const fn = mocked(setTimeout).mock.calls[0][0];
+
+  await fn();
+
+  expect(error1).toBeDefined();
+  expect(error2).toBeDefined();
+});

--- a/packages/facebook-batch/src/__tests__/FacebookBatchQueue.spec.ts
+++ b/packages/facebook-batch/src/__tests__/FacebookBatchQueue.spec.ts
@@ -67,13 +67,12 @@ it('should flush when length >= 50', async () => {
     .fill(0)
     .map(() => ({
       code: 200,
-      body: '{"data": []}',
+      body: { data: [] },
     }));
 
   mocked(client.sendBatch).mockResolvedValue(responses);
 
   for (let i = 0; i < 49; i++) {
-    // eslint-disable-next-line no-await-in-loop
     queue.push(MessengerBatch.sendText('1412611362105802', 'hello'));
   }
 
@@ -109,7 +108,7 @@ it('should flush with 1000 timeout', async () => {
   const responses = [
     {
       code: 200,
-      body: '{"data": []}',
+      body: { data: [] },
     },
   ];
 
@@ -154,7 +153,7 @@ it('should not send batch when with empty array', async () => {
   const responses = [
     {
       code: 200,
-      body: '{"data": []}',
+      body: { data: [] },
     },
   ];
 
@@ -177,7 +176,7 @@ it('should reset timeout when flush', async () => {
     .fill(0)
     .map(() => ({
       code: 200,
-      body: '{"data": []}',
+      body: { data: [] },
     }));
 
   mocked(client.sendBatch).mockResolvedValue(responses);
@@ -204,12 +203,16 @@ it('should throw request and response', async () => {
   const responses = [
     {
       code: 400,
-      body:
-        '{"error": {"message": "(#100) Param recipient[id] must be a valid ID string (e.g., \\"123\\")"} }',
+      body: {
+        error: {
+          message:
+            '(#100) Param recipient[id] must be a valid ID string (e.g., "123")',
+        },
+      },
     },
   ];
 
-  mocked(client.sendBatch).mockReturnValue(Promise.resolve(responses));
+  mocked(client.sendBatch).mockResolvedValue(responses);
 
   let error: BatchRequestError | undefined;
 
@@ -245,8 +248,12 @@ it('should throw request and response', async () => {
     relativeUrl: 'me/messages',
   });
   expect(error!.response).toEqual({
-    body:
-      '{"error": {"message": "(#100) Param recipient[id] must be a valid ID string (e.g., \\"123\\")"} }',
+    body: {
+      error: {
+        message:
+          '(#100) Param recipient[id] must be a valid ID string (e.g., "123")',
+      },
+    },
     code: 400,
   });
 });
@@ -257,7 +264,7 @@ it('should support delay option', async () => {
   const responses = [
     {
       code: 200,
-      body: '{"data": []}',
+      body: { data: [] },
     },
   ];
 
@@ -273,8 +280,12 @@ it('should support retryTimes option', async () => {
   const responses = [
     {
       code: 400,
-      body:
-        '{"error": {"message": "(#100) Param recipient[id] must be a valid ID string (e.g., \\"123\\")"} }',
+      body: {
+        error: {
+          message:
+            '(#100) Param recipient[id] must be a valid ID string (e.g., "123")',
+        },
+      },
     },
   ];
 
@@ -311,13 +322,20 @@ it('should support shouldRetry option', async () => {
   const responses = [
     {
       code: 400,
-      body:
-        '{"error": {"message": "(#100) Param recipient[id] must be a valid ID string (e.g., \\"123\\")"} }',
+      body: {
+        error: {
+          message:
+            '(#100) Param recipient[id] must be a valid ID string (e.g., "123")',
+        },
+      },
     },
     {
       code: 400,
-      body:
-        '{"error": {"message": "(#613) Calls to this api have exceeded the rate limit."} }',
+      body: {
+        error: {
+          message: '(#613) Calls to this api have exceeded the rate limit.',
+        },
+      },
     },
   ];
 
@@ -342,6 +360,7 @@ it('should support shouldRetry option', async () => {
   const fn = mocked(setTimeout).mock.calls[0][0];
 
   await fn();
+
   expect(queue.queue).toHaveLength(1);
   expect(client.sendBatch).toHaveBeenCalledTimes(1);
   expect(mocked(client.sendBatch).mock.calls[0][0]).toHaveLength(2);

--- a/packages/facebook-batch/src/__tests__/__snapshots__/BatchRequestError.spec.ts.snap
+++ b/packages/facebook-batch/src/__tests__/__snapshots__/BatchRequestError.spec.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should work 1`] = `
+"
+Error Message - Batch Request Error
+
+Request -
+
+POST me/feed
+message=Test status update&amp;link=http://developers.facebook.com/
+
+Response -
+403
+{\\"error\\":{\\"type\\":\\"OAuthException\\",\\"message\\": \\"Invalid parameter\\",\\"code\\": 100}}
+    "
+`;

--- a/packages/facebook-batch/src/__tests__/__snapshots__/BatchRequestError.spec.ts.snap
+++ b/packages/facebook-batch/src/__tests__/__snapshots__/BatchRequestError.spec.ts.snap
@@ -7,10 +7,19 @@ Error Message - Batch Request Error
 Request -
 
 POST me/feed
-message=Test status update&amp;link=http://developers.facebook.com/
+{
+  \\"message\\": \\"Test status update\\",
+  \\"link\\": \\"http://developers.facebook.com/\\"
+}
 
 Response -
 403
-{\\"error\\":{\\"type\\":\\"OAuthException\\",\\"message\\": \\"Invalid parameter\\",\\"code\\": 100}}
+{
+  \\"error\\": {
+    \\"type\\": \\"OAuthException\\",
+    \\"message\\": \\"Invalid parameter\\",
+    \\"code\\": 100
+  }
+}
     "
 `;

--- a/packages/facebook-batch/src/__tests__/index.spec.ts
+++ b/packages/facebook-batch/src/__tests__/index.spec.ts
@@ -1,0 +1,13 @@
+import { BatchRequestError, FacebookBatchQueue, isError613 } from '..';
+
+it('FacebookBatchQueue should be exported', () => {
+  expect(FacebookBatchQueue).toBeDefined();
+});
+
+it('BatchRequestError should be exported', () => {
+  expect(BatchRequestError).toBeDefined();
+});
+
+it('error predicate should be exported', () => {
+  expect(isError613).toBeDefined();
+});

--- a/packages/facebook-batch/src/index.ts
+++ b/packages/facebook-batch/src/index.ts
@@ -1,0 +1,5 @@
+import BatchRequestError from './BatchRequestError';
+import FacebookBatchQueue from './FacebookBatchQueue';
+import { getErrorMessage, isError613 } from './utils';
+
+export { getErrorMessage, isError613, FacebookBatchQueue, BatchRequestError };

--- a/packages/facebook-batch/src/types.ts
+++ b/packages/facebook-batch/src/types.ts
@@ -21,13 +21,21 @@ export type QueueItem = {
   retry?: number;
 };
 
-export type BatchResponse = {
+export type BatchResponse<T extends JsonObject = JsonObject> = {
   code: number;
   headers?: { name: string; value: string }[];
-  body: string;
+  body: T;
 };
+
+export type BatchErrorResponse = BatchResponse<{
+  error: {
+    type: string;
+    message: string;
+    code: number;
+  };
+}>;
 
 export type BatchRequestErrorInfo = {
   request: BatchRequest;
-  response: BatchResponse;
+  response: BatchErrorResponse;
 };

--- a/packages/facebook-batch/src/types.ts
+++ b/packages/facebook-batch/src/types.ts
@@ -1,0 +1,33 @@
+import { JsonObject } from 'type-fest';
+
+export type BatchRequestOptions = {
+  name?: string;
+  dependsOn?: string;
+};
+
+export type BatchRequest = {
+  method: string;
+  relativeUrl: string;
+  name?: string;
+  body?: JsonObject;
+  responseAccessPath?: string;
+} & BatchRequestOptions;
+
+export type QueueItem = {
+  request: BatchRequest;
+  resolve: (value?: unknown) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject: (reason?: any) => void;
+  retry?: number;
+};
+
+export type BatchResponse = {
+  code: number;
+  headers?: { name: string; value: string }[];
+  body: string;
+};
+
+export type BatchRequestErrorInfo = {
+  request: BatchRequest;
+  response: BatchResponse;
+};

--- a/packages/facebook-batch/src/utils.ts
+++ b/packages/facebook-batch/src/utils.ts
@@ -1,0 +1,15 @@
+import { BatchRequestErrorInfo } from './types';
+
+export function getErrorMessage(errInfo: BatchRequestErrorInfo): string {
+  try {
+    const { message } = JSON.parse(errInfo.response.body).error;
+    return message;
+  } catch (_) {
+    return '';
+  }
+}
+
+export function isError613(errInfo: BatchRequestErrorInfo): boolean {
+  const message = getErrorMessage(errInfo);
+  return /#613/.test(message);
+}

--- a/packages/facebook-batch/src/utils.ts
+++ b/packages/facebook-batch/src/utils.ts
@@ -2,7 +2,7 @@ import { BatchRequestErrorInfo } from './types';
 
 export function getErrorMessage(errInfo: BatchRequestErrorInfo): string {
   try {
-    const { message } = JSON.parse(errInfo.response.body).error;
+    const message = errInfo.response.body?.error?.message;
     return message;
   } catch (_) {
     return '';

--- a/packages/facebook-batch/tsconfig.json
+++ b/packages/facebook-batch/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__"]
+}

--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -1194,7 +1194,13 @@ export default class MessengerClient {
   sendBatch(
     batch: Types.BatchItem[],
     { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
-  ): Promise<Types.SendMessageSuccessResponse[]> {
+  ): Promise<
+    {
+      code: number;
+      headers?: { name: string; value: string }[];
+      body: string;
+    }[]
+  > {
     invariant(
       batch.length <= 50,
       'limit the number of requests which can be in a batch to 50'

--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -1198,7 +1198,7 @@ export default class MessengerClient {
     {
       code: number;
       headers?: { name: string; value: string }[];
-      body: string;
+      body: Record<string, any>;
     }[]
   > {
     invariant(
@@ -1239,15 +1239,13 @@ export default class MessengerClient {
             (item: { code: number; body: string }, index: number) => {
               const responseAccessPath = responseAccessPaths[index];
               const datum = camelcaseKeysDeep(item) as Record<string, any>;
-              if (responseAccessPath && datum.body) {
+              if (datum.body) {
+                const parsedBody = camelcaseKeysDeep(JSON.parse(datum.body));
                 return {
                   ...datum,
-                  body: JSON.stringify(
-                    get(
-                      camelcaseKeysDeep(JSON.parse(datum.body)),
-                      responseAccessPath
-                    )
-                  ),
+                  body: responseAccessPath
+                    ? get(parsedBody, responseAccessPath)
+                    : parsedBody,
                 };
               }
               return datum;

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.ts
@@ -1143,8 +1143,9 @@ describe('send api', () => {
 
       const reply = [
         {
-          recipient_id: USER_ID,
-          message_id: 'mid.1489394984387:3dd22de509',
+          code: 200,
+          body:
+            '{"recipient_id":"1QAZ2WSX","message_id":"mid.1489394984387:3dd22de509"}',
         },
       ];
 
@@ -1174,8 +1175,11 @@ describe('send api', () => {
 
       expect(res).toEqual([
         {
-          recipientId: USER_ID,
-          messageId: 'mid.1489394984387:3dd22de509',
+          code: 200,
+          body: {
+            recipientId: USER_ID,
+            messageId: 'mid.1489394984387:3dd22de509',
+          },
         },
       ]);
     });
@@ -1184,7 +1188,10 @@ describe('send api', () => {
       const { client, mock } = createMock();
 
       const reply = [
-        { body: '{"data":[{"thread_owner":{"app_id":"501514720355337"}}]}' },
+        {
+          code: 200,
+          body: '{"data":[{"thread_owner":{"app_id":"501514720355337"}}]}',
+        },
       ];
 
       const batch = [MessengerBatch.getThreadOwner(USER_ID)];
@@ -1210,7 +1217,12 @@ describe('send api', () => {
         ],
       });
 
-      expect(res).toEqual([{ body: '{"appId":"501514720355337"}' }]);
+      expect(res).toEqual([
+        {
+          code: 200,
+          body: { appId: '501514720355337' },
+        },
+      ]);
     });
 
     it('should throw if item length > 50', async () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,6 +12,7 @@
     { "path": "./packages/messaging-api-slack" },
     { "path": "./packages/messaging-api-telegram" },
     { "path": "./packages/messaging-api-viber" },
-    { "path": "./packages/messaging-api-wechat" }
+    { "path": "./packages/messaging-api-wechat" },
+    { "path": "./packages/facebook-batch" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,6 +3157,17 @@ eslint-import-resolver-node@^0.3.3:
     debug "^2.6.9"
     resolve "^1.13.1"
 
+eslint-import-resolver-typescript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.0.0.tgz#e95f126cc12d3018b9cc11692b4dbfd3e17d3ea6"
+  integrity sha512-bT5Frpl8UWoHBtY25vKUOMoVIMlJQOMefHLyQ4Tz3MQpIZ2N6yYKEEIHMo38bszBNUuMBW6M3+5JNYxeiGFH4w==
+  dependencies:
+    debug "^4.1.1"
+    is-glob "^4.0.1"
+    resolve "^1.12.0"
+    tiny-glob "^0.2.6"
+    tsconfig-paths "^3.9.0"
+
 eslint-module-utils@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
@@ -3947,6 +3958,11 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
+globalyzer@^0.1.0:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.4.tgz#bc8e273afe1ac7c24eea8def5b802340c5cc534f"
+  integrity sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==
+
 globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
@@ -3960,6 +3976,11 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
+
+globrex@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.3"
@@ -5599,6 +5620,18 @@ merge2@^1.2.3:
     snake-case "^3.0.3"
     url-join "^4.0.1"
 
+"messaging-api-messenger@file:packages/messaging-api-messenger":
+  version "1.0.0-beta.25"
+  dependencies:
+    append-query "^2.1.0"
+    axios "^0.19.2"
+    axios-error "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.0-beta.25-d1263e36-d376-473b-b99d-10d47666b6b2-1592810064179/node_modules/axios-error"
+    form-data "^3.0.0"
+    invariant "^2.2.4"
+    lodash "^4.17.15"
+    messaging-api-common "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.0-beta.25-d1263e36-d376-473b-b99d-10d47666b6b2-1592810064179/node_modules/messaging-api-common"
+    warning "^4.0.3"
+
 micromatch@4.x, micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
@@ -6954,7 +6987,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.17.0:
+resolve@^1.1.6, resolve@^1.12.0, resolve@^1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -7770,6 +7803,14 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+tiny-glob@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.6.tgz#9e056e169d9788fe8a734dfa1ff02e9b92ed7eda"
+  integrity sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==
+  dependencies:
+    globalyzer "^0.1.0"
+    globrex "^0.1.1"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -7938,6 +7979,11 @@ type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
+type-fest@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.15.1.tgz#d2c4e73d3e4a53cf1a906396dd460a1c5178ca00"
+  integrity sha512-n+UXrN8i5ioo7kqT/nF8xsEzLaqFra7k32SEsSPwvXVGyAcRgV/FUQN/sgfptJTR1oRmmq7z4IXMFSM7im7C9A==
 
 type-fest@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
https://github.com/Yoctol/messenger-batch

This module is not only used by Messenger but also used by Facebook and Instagram, so I'm renaming it to `facebook-batch`.

And we're going to make it highly integrate to our clients, so here is the right place to host it.

Note: this PR introduces a breaking change to resolve object body instead of string body in the `sendBatch` API:

Before:

```js
await client.sendBatch([ /* ... */])
// => [{
//     code: 200,
//     body: '{"recipientId":"1QAZ2WSX","messageId":"mid.1489394984387:3dd22de509"}',
// }]
```

After:

```js
await client.sendBatch([ /* ... */])
// => [{
//     code: 200,
//     body: {
//       "recipientId": "1QAZ2WSX",
//       "messageId": "mid.1489394984387:3dd22de509"
//     },
// }]
```
