### PR TITLE
type(facebook-batch): export types

### DIFF
--- a/packages/facebook-batch/src/FacebookBatchQueue.ts
+++ b/packages/facebook-batch/src/FacebookBatchQueue.ts
@@ -4,6 +4,7 @@ import { MessengerClient } from 'messaging-api-messenger';
 
 import BatchRequestError from './BatchRequestError';
 import {
+  BatchConfig,
   BatchErrorResponse,
   BatchRequest,
   BatchRequestErrorInfo,
@@ -27,14 +28,7 @@ export default class FacebookBatchQueue {
 
   _timeout: NodeJS.Timeout;
 
-  constructor(
-    client: MessengerClient,
-    options: {
-      delay?: number;
-      shouldRetry?: (err: BatchRequestErrorInfo) => boolean;
-      retryTimes?: number;
-    } = {}
-  ) {
+  constructor(client: MessengerClient, options: BatchConfig = {}) {
     invariant(
       client,
       'Must provide a MessengerClient or FacebookClient instance'

--- a/packages/facebook-batch/src/index.ts
+++ b/packages/facebook-batch/src/index.ts
@@ -3,3 +3,4 @@ import FacebookBatchQueue from './FacebookBatchQueue';
 import { getErrorMessage, isError613 } from './utils';
 
 export { getErrorMessage, isError613, FacebookBatchQueue, BatchRequestError };
+export * from './types';

--- a/packages/facebook-batch/src/types.ts
+++ b/packages/facebook-batch/src/types.ts
@@ -39,3 +39,9 @@ export type BatchRequestErrorInfo = {
   request: BatchRequest;
   response: BatchErrorResponse;
 };
+
+export type BatchConfig = {
+  delay?: number;
+  shouldRetry?: (err: BatchRequestErrorInfo) => boolean;
+  retryTimes?: number;
+};


### PR DESCRIPTION
We need this `BatchConfig` type in Bottender,  so let's export it.