### PR TITLE
changed(facebook-batch): construct queue using client config instead of client

### DIFF
--- a/packages/facebook-batch/package.json
+++ b/packages/facebook-batch/package.json
@@ -11,7 +11,6 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "messaging-api-messenger": "file:../messaging-api-messenger",
-    "ts-invariant": "^0.4.4",
     "type-fest": "^0.15.1"
   },
   "keywords": [

--- a/packages/facebook-batch/src/FacebookBatchQueue.ts
+++ b/packages/facebook-batch/src/FacebookBatchQueue.ts
@@ -1,6 +1,5 @@
-import invariant from 'ts-invariant';
 import { JsonObject } from 'type-fest';
-import { MessengerClient } from 'messaging-api-messenger';
+import { MessengerClient, MessengerTypes } from 'messaging-api-messenger';
 
 import BatchRequestError from './BatchRequestError';
 import {
@@ -48,15 +47,14 @@ export default class FacebookBatchQueue {
    * });
    * ```
    */
-  constructor(client: MessengerClient, options: BatchConfig = {}) {
-    invariant(
-      client,
-      'Must provide a MessengerClient or FacebookClient instance'
-    );
-
+  constructor(
+    clientConfig: MessengerTypes.ClientConfig,
+    options: BatchConfig = {}
+  ) {
     this.queue = [];
 
-    this.client = client;
+    // TODO: we use messenger client here for now, but maybe we will replace it with some facebook base client
+    this.client = new MessengerClient(clientConfig);
     this.delay = options.delay ?? 1000;
     this.shouldRetry = options.shouldRetry ?? alwaysTrue;
     this.retryTimes = options.retryTimes ?? 0;

--- a/packages/facebook-batch/src/__tests__/FacebookBatchQueue.spec.ts
+++ b/packages/facebook-batch/src/__tests__/FacebookBatchQueue.spec.ts
@@ -36,11 +36,15 @@ function setup(
   };
   mocked(setTimeout).mockReturnValue(timeout);
 
-  const client = new MessengerClient({
-    accessToken: 'ACCESS_TOKEN',
-    appSecret: 'APP_SECRET',
-  });
-  queue = new FacebookBatchQueue(client, options);
+  queue = new FacebookBatchQueue(
+    {
+      accessToken: 'ACCESS_TOKEN',
+      appSecret: 'APP_SECRET',
+    },
+    options
+  );
+
+  const client = mocked(MessengerClient).mock.instances[0];
 
   return {
     client,


### PR DESCRIPTION
Per discussion with @etrex last week, we decided to pass config instead of a client to avoid future cyclic dependency.