### PR TITLE
fix(facebook-batch): bq.push should resolve JSONValue instead of JSONObject

### DIFF
--- a/packages/facebook-batch/src/FacebookBatchQueue.ts
+++ b/packages/facebook-batch/src/FacebookBatchQueue.ts
@@ -1,4 +1,4 @@
-import { JsonObject } from 'type-fest';
+import { JsonValue } from 'type-fest';
 import { MessengerClient, MessengerTypes } from 'messaging-api-messenger';
 
 import BatchRequestError from './BatchRequestError';
@@ -86,7 +86,7 @@ export default class FacebookBatchQueue {
    * ```
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  push<T extends JsonObject = any>(request: BatchRequest): Promise<T> {
+  push<T extends JsonValue = any>(request: BatchRequest): Promise<T> {
     const promise = new Promise((resolve, reject) => {
       this.queue.push({ request, resolve, reject });
     });


### PR DESCRIPTION
Sometimes we need to resolve some arrays here, so it should use JSONValue instead of JSONObject.