### PR TITLE
changed(constructor): remove string support in constructor

### DIFF
--- a/packages/messaging-api-line/src/LineClient.ts
+++ b/packages/messaging-api-line/src/LineClient.ts
@@ -87,7 +87,7 @@ export default class LineClient {
    * })
    * ```
    *
-   * @param config - your channel access token from LINE Messaging API or [[ClientConfig]]
+   * @param config - [[ClientConfig]]
    * @param channelSecret - your channel secret from LINE Messaging API
    */
   constructor(config: Types.ClientConfig) {

--- a/packages/messaging-api-line/src/LineClient.ts
+++ b/packages/messaging-api-line/src/LineClient.ts
@@ -43,15 +43,12 @@ export default class LineClient {
   /**
    * @deprecated Use `new LineClient(...)` instead.
    */
-  static connect(
-    accessTokenOrConfig: string | Types.ClientConfig,
-    channelSecret?: string
-  ): LineClient {
+  static connect(config: Types.ClientConfig): LineClient {
     warning(
       false,
       '`LineClient.connect(...)` is deprecated. Use `new LineClient(...)` instead.'
     );
-    return new LineClient(accessTokenOrConfig, channelSecret);
+    return new LineClient(config);
   }
 
   /**
@@ -84,37 +81,25 @@ export default class LineClient {
    *
    * Usage:
    * ```ts
-   * new LineClient(ACCESS_TOKEN, CHANNEL_SECRET)
-   * ```
-   * or
-   * ```ts
    * new LineClient({
    *   accessToken: ACCESS_TOKEN,
    *   channelSecret: CHANNEL_SECRET
    * })
    * ```
    *
-   * @param accessTokenOrConfig - your channel access token from LINE Messaging API or [[ClientConfig]]
+   * @param config - your channel access token from LINE Messaging API or [[ClientConfig]]
    * @param channelSecret - your channel secret from LINE Messaging API
    */
-  constructor(
-    accessTokenOrConfig: string | Types.ClientConfig,
-    channelSecret?: string
-  ) {
-    let origin;
-    let dataOrigin;
-    if (accessTokenOrConfig && typeof accessTokenOrConfig === 'object') {
-      const config = accessTokenOrConfig;
+  constructor(config: Types.ClientConfig) {
+    invariant(
+      typeof config !== 'string',
+      `LineClient: do not allow constructing client with ${config} string. Use object instead.`
+    );
 
-      this.accessToken = config.accessToken;
-      this.channelSecret = config.channelSecret;
-      this.onRequest = config.onRequest;
-      origin = config.origin;
-      dataOrigin = config.dataOrigin;
-    } else {
-      this.accessToken = accessTokenOrConfig;
-      this.channelSecret = channelSecret as string;
-    }
+    this.accessToken = config.accessToken;
+    this.channelSecret = config.channelSecret;
+    this.onRequest = config.onRequest;
+    const { origin, dataOrigin } = config;
 
     this.axios = axios.create({
       baseURL: `${origin || 'https://api.line.me'}/`,

--- a/packages/messaging-api-line/src/LineClient.ts
+++ b/packages/messaging-api-line/src/LineClient.ts
@@ -88,7 +88,6 @@ export default class LineClient {
    * ```
    *
    * @param config - [[ClientConfig]]
-   * @param channelSecret - your channel secret from LINE Messaging API
    */
   constructor(config: Types.ClientConfig) {
     invariant(

--- a/packages/messaging-api-line/src/__tests__/LineClient-audience.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-audience.spec.ts
@@ -14,7 +14,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const headers = {
     Accept: 'application/json, text/plain, */*',

--- a/packages/messaging-api-line/src/__tests__/LineClient-constructor.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-constructor.spec.ts
@@ -18,25 +18,6 @@ describe('connect', () => {
   });
 
   describe('create axios with Line API', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      LineClient.connect(ACCESS_TOKEN, CHANNEL_SECRET);
-
-      expect(axios.create).toBeCalledWith({
-        baseURL: 'https://api.line.me/',
-        headers: {
-          Authorization: `Bearer ${ACCESS_TOKEN}`,
-          'Content-Type': 'application/json',
-        },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -97,25 +78,6 @@ describe('constructor', () => {
   });
 
   describe('create axios with Line API', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      new LineClient(ACCESS_TOKEN, CHANNEL_SECRET); // eslint-disable-line no-new
-
-      expect(axios.create).toBeCalledWith({
-        baseURL: 'https://api.line.me/',
-        headers: {
-          Authorization: `Bearer ${ACCESS_TOKEN}`,
-          'Content-Type': 'application/json',
-        },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -167,16 +129,11 @@ describe('constructor', () => {
 
 describe('#axios', () => {
   it('should return underlying http client', () => {
-    let client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
-    expect(client.axios.get).toBeDefined();
-    expect(client.axios.post).toBeDefined();
-    expect(client.axios.put).toBeDefined();
-    expect(client.axios.delete).toBeDefined();
-
-    client = new LineClient({
+    const client = new LineClient({
       accessToken: ACCESS_TOKEN,
       channelSecret: CHANNEL_SECRET,
     });
+
     expect(client.axios.get).toBeDefined();
     expect(client.axios.post).toBeDefined();
     expect(client.axios.put).toBeDefined();
@@ -186,13 +143,11 @@ describe('#axios', () => {
 
 describe('#accessToken', () => {
   it('should return underlying access token', () => {
-    let client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
-    expect(client.accessToken).toBe(ACCESS_TOKEN);
-
-    client = new LineClient({
+    const client = new LineClient({
       accessToken: ACCESS_TOKEN,
       channelSecret: CHANNEL_SECRET,
     });
+
     expect(client.accessToken).toBe(ACCESS_TOKEN);
   });
 });
@@ -245,15 +200,7 @@ describe('Client instance', () => {
       'ImageCarouselTemplate',
     ];
 
-    let client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
-
-    sendTypes.forEach((sendType) => {
-      messageTypes.forEach((messageType) => {
-        expect(client[`${sendType}${messageType}`]).toBeDefined();
-      });
-    });
-
-    client = new LineClient({
+    const client = new LineClient({
       accessToken: ACCESS_TOKEN,
       channelSecret: CHANNEL_SECRET,
     });

--- a/packages/messaging-api-line/src/__tests__/LineClient-insight.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-insight.spec.ts
@@ -14,7 +14,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const headers = {
     Accept: 'application/json, text/plain, */*',

--- a/packages/messaging-api-line/src/__tests__/LineClient-liff.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-liff.spec.ts
@@ -14,7 +14,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const headers = {
     Accept: 'application/json, text/plain, */*',

--- a/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-menu.spec.ts
@@ -18,7 +18,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const dataMock = new MockAdapter(client.dataAxios);
   const headers = {

--- a/packages/messaging-api-line/src/__tests__/LineClient-multicast.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-multicast.spec.ts
@@ -15,7 +15,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const headers = {
     Accept: 'application/json, text/plain, */*',

--- a/packages/messaging-api-line/src/__tests__/LineClient-narrowcast.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-narrowcast.spec.ts
@@ -15,7 +15,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const headers = {
     Accept: 'application/json, text/plain, */*',

--- a/packages/messaging-api-line/src/__tests__/LineClient-push.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-push.spec.ts
@@ -15,7 +15,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const headers = {
     Accept: 'application/json, text/plain, */*',

--- a/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-reply.spec.ts
@@ -15,7 +15,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const headers = {
     Accept: 'application/json, text/plain, */*',

--- a/packages/messaging-api-line/src/__tests__/LineClient-room-group.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient-room-group.spec.ts
@@ -17,7 +17,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const headers = {
     Accept: 'application/json, text/plain, */*',

--- a/packages/messaging-api-line/src/__tests__/LineClient.spec.ts
+++ b/packages/messaging-api-line/src/__tests__/LineClient.spec.ts
@@ -17,7 +17,10 @@ const createMock = (): {
     Authorization: string;
   };
 } => {
-  const client = new LineClient(ACCESS_TOKEN, CHANNEL_SECRET);
+  const client = new LineClient({
+    accessToken: ACCESS_TOKEN,
+    channelSecret: CHANNEL_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
   const dataMock = new MockAdapter(client.dataAxios);
   const headers = {

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.ts
@@ -19,24 +19,6 @@ afterEach(() => {
 
 describe('connect', () => {
   describe('create axios with default graphAPI version', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      MessengerClient.connect(ACCESS_TOKEN);
-
-      expect(axios.create).toBeCalledWith(
-        expect.objectContaining({
-          baseURL: 'https://graph.facebook.com/v6.0/',
-          headers: { 'Content-Type': 'application/json' },
-        })
-      );
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -57,24 +39,6 @@ describe('connect', () => {
   });
 
   describe('create axios with custom graphAPI version', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      MessengerClient.connect(ACCESS_TOKEN, '2.6');
-
-      expect(axios.create).toBeCalledWith(
-        expect.objectContaining({
-          baseURL: 'https://graph.facebook.com/v2.6/',
-          headers: { 'Content-Type': 'application/json' },
-        })
-      );
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -118,24 +82,6 @@ describe('connect', () => {
 
 describe('constructor', () => {
   describe('create axios with default graphAPI version', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      new MessengerClient(ACCESS_TOKEN); // eslint-disable-line no-new
-
-      expect(axios.create).toBeCalledWith(
-        expect.objectContaining({
-          baseURL: 'https://graph.facebook.com/v6.0/',
-          headers: { 'Content-Type': 'application/json' },
-        })
-      );
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -156,24 +102,6 @@ describe('constructor', () => {
   });
 
   describe('create axios with custom graphAPI version', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      new MessengerClient(ACCESS_TOKEN, '2.6'); // eslint-disable-line no-new
-
-      expect(axios.create).toBeCalledWith(
-        expect.objectContaining({
-          baseURL: 'https://graph.facebook.com/v2.6/',
-          headers: { 'Content-Type': 'application/json' },
-        })
-      );
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -218,14 +146,6 @@ describe('constructor', () => {
 
 describe('#version', () => {
   it('should return version of graph api', () => {
-    expect(new MessengerClient(ACCESS_TOKEN).version).toEqual('6.0');
-    expect(new MessengerClient(ACCESS_TOKEN, 'v2.6').version).toEqual('2.6');
-    expect(new MessengerClient(ACCESS_TOKEN, '2.6').version).toEqual('2.6');
-    expect(() => {
-      // eslint-disable-next-line no-new
-      new MessengerClient(ACCESS_TOKEN, 2.6);
-    }).toThrow('Type of `version` must be string.');
-
     expect(new MessengerClient({ accessToken: ACCESS_TOKEN }).version).toEqual(
       '6.0'
     );
@@ -245,13 +165,8 @@ describe('#version', () => {
 
 describe('#axios', () => {
   it('should return underlying http client', () => {
-    let client = new MessengerClient(ACCESS_TOKEN);
-    expect(client.axios.get).toBeDefined();
-    expect(client.axios.post).toBeDefined();
-    expect(client.axios.put).toBeDefined();
-    expect(client.axios.delete).toBeDefined();
+    const client = new MessengerClient({ accessToken: ACCESS_TOKEN });
 
-    client = new MessengerClient({ accessToken: ACCESS_TOKEN });
     expect(client.axios.get).toBeDefined();
     expect(client.axios.post).toBeDefined();
     expect(client.axios.put).toBeDefined();
@@ -261,10 +176,8 @@ describe('#axios', () => {
 
 describe('#accessToken', () => {
   it('should return underlying access token', () => {
-    let client = new MessengerClient(ACCESS_TOKEN);
-    expect(client.accessToken).toBe(ACCESS_TOKEN);
+    const client = new MessengerClient({ accessToken: ACCESS_TOKEN });
 
-    client = new MessengerClient({ accessToken: ACCESS_TOKEN });
     expect(client.accessToken).toBe(ACCESS_TOKEN);
   });
 });

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-handover.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-handover.spec.ts
@@ -17,7 +17,9 @@ afterEach(() => {
 });
 
 const createMock = (): { client: MessengerClient; mock: MockAdapter } => {
-  const client = new MessengerClient(ACCESS_TOKEN);
+  const client = new MessengerClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-insights.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-insights.spec.ts
@@ -16,7 +16,9 @@ afterEach(() => {
 });
 
 const createMock = (): { client: MessengerClient; mock: MockAdapter } => {
-  const client = new MessengerClient(ACCESS_TOKEN);
+  const client = new MessengerClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-persona.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-persona.spec.ts
@@ -16,7 +16,9 @@ afterEach(() => {
 });
 
 const createMock = (): { client: MessengerClient; mock: MockAdapter } => {
-  const client = new MessengerClient(ACCESS_TOKEN);
+  const client = new MessengerClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-profile.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-profile.spec.ts
@@ -17,7 +17,9 @@ afterEach(() => {
 });
 
 const createMock = (): { client: MessengerClient; mock: MockAdapter } => {
-  const client = new MessengerClient(ACCESS_TOKEN);
+  const client = new MessengerClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.ts
@@ -22,7 +22,9 @@ afterEach(() => {
 });
 
 const createMock = (): { client: MessengerClient; mock: MockAdapter } => {
-  const client = new MessengerClient(ACCESS_TOKEN);
+  const client = new MessengerClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-sendTemplate.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-sendTemplate.spec.ts
@@ -17,7 +17,9 @@ afterEach(() => {
 });
 
 const createMock = (): { client: MessengerClient; mock: MockAdapter } => {
-  const client = new MessengerClient(ACCESS_TOKEN);
+  const client = new MessengerClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-slack/package.json
+++ b/packages/messaging-api-slack/package.json
@@ -15,7 +15,8 @@
     "axios": "^0.19.2",
     "axios-error": "^1.0.0-beta.27",
     "lodash": "^4.17.15",
-    "messaging-api-common": "^1.0.0-beta.29"
+    "messaging-api-common": "^1.0.0-beta.29",
+    "ts-invariant": "^0.4.4"
   },
   "keywords": [
     "bot",

--- a/packages/messaging-api-slack/src/SlackOAuthClient.ts
+++ b/packages/messaging-api-slack/src/SlackOAuthClient.ts
@@ -2,6 +2,7 @@ import querystring from 'querystring';
 
 import AxiosError from 'axios-error';
 import axios, { AxiosInstance } from 'axios';
+import invariant from 'ts-invariant';
 import omit from 'lodash/omit';
 import warning from 'warning';
 import {
@@ -33,14 +34,12 @@ export default class SlackOAuthClient {
   /**
    * @deprecated Use `new SlackOAuthClient(...)` instead.
    */
-  static connect(
-    accessTokenOrConfig: string | Types.ClientConfig
-  ): SlackOAuthClient {
+  static connect(config: Types.ClientConfig): SlackOAuthClient {
     warning(
       false,
       '`SlackOAuthClient.connect(...)` is deprecated. Use `new SlackOAuthClient(...)` instead.'
     );
-    return new SlackOAuthClient(accessTokenOrConfig);
+    return new SlackOAuthClient(config);
   }
 
   /**
@@ -108,24 +107,19 @@ export default class SlackOAuthClient {
    */
   private onRequest?: OnRequestFunction;
 
-  constructor(accessTokenOrConfig: string | Types.ClientConfig) {
-    let origin;
+  constructor(config: Types.ClientConfig) {
+    invariant(
+      typeof config !== 'string',
+      `SlackOAuthClient: do not allow constructing client with ${config} string. Use object instead.`
+    );
 
-    if (typeof accessTokenOrConfig === 'string') {
-      // Bot User OAuth Access Token
-      this.accessToken = accessTokenOrConfig;
-    } else {
-      const config = accessTokenOrConfig;
-
-      this.accessToken = config.accessToken;
-      this.onRequest = config.onRequest;
-      origin = config.origin;
-    }
+    this.accessToken = config.accessToken;
+    this.onRequest = config.onRequest;
 
     // Web API
     // https://api.slack.com/web
     this.axios = axios.create({
-      baseURL: `${origin || 'https://slack.com'}/api/`,
+      baseURL: `${config.origin || 'https://slack.com'}/api/`,
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },

--- a/packages/messaging-api-slack/src/SlackWebhookClient.ts
+++ b/packages/messaging-api-slack/src/SlackWebhookClient.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import invariant from 'ts-invariant';
 import warning from 'warning';
 import {
   OnRequestFunction,
@@ -17,12 +18,12 @@ export default class SlackWebhookClient {
   /**
    * @deprecated Use `new SlackWebhookClient(...)` instead.
    */
-  static connect(urlOrConfig: string | ClientConfig): SlackWebhookClient {
+  static connect(config: ClientConfig): SlackWebhookClient {
     warning(
       false,
       '`SlackWebhookClient.connect(...)` is deprecated. Use `new SlackWebhookClient(...)` instead.'
     );
-    return new SlackWebhookClient(urlOrConfig);
+    return new SlackWebhookClient(config);
   }
 
   /**
@@ -35,22 +36,18 @@ export default class SlackWebhookClient {
    */
   private onRequest?: OnRequestFunction;
 
-  constructor(urlOrConfig: string | ClientConfig) {
-    let url;
+  constructor(config: ClientConfig) {
+    invariant(
+      typeof config !== 'string',
+      `SlackWebhookClient: do not allow constructing client with ${config} string. Use object instead.`
+    );
 
-    if (urlOrConfig && typeof urlOrConfig === 'object') {
-      const config = urlOrConfig;
-
-      url = config.url;
-      this.onRequest = config.onRequest;
-    } else {
-      url = urlOrConfig;
-    }
+    this.onRequest = config.onRequest;
 
     // incoming webhooks
     // https://api.slack.com/incoming-webhooks
     this.axios = axios.create({
-      baseURL: url,
+      baseURL: config.url,
       headers: { 'Content-Type': 'application/json' },
     });
 

--- a/packages/messaging-api-slack/src/__tests__/SlackOAuthClient-constructor.spec.ts
+++ b/packages/messaging-api-slack/src/__tests__/SlackOAuthClient-constructor.spec.ts
@@ -17,22 +17,6 @@ describe('connect', () => {
   });
 
   describe('create axios with slack api url', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      SlackOAuthClient.connect(TOKEN);
-
-      expect(axios.create).toBeCalledWith({
-        baseURL: 'https://slack.com/api/',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -83,22 +67,6 @@ describe('constructor', () => {
   });
 
   describe('create axios with with slack api url', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      new SlackOAuthClient(TOKEN); // eslint-disable-line no-new
-
-      expect(axios.create).toBeCalledWith({
-        baseURL: 'https://slack.com/api/',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -139,13 +107,8 @@ describe('constructor', () => {
 
 describe('#axios', () => {
   it('should return underlying http client', () => {
-    let client = new SlackOAuthClient(TOKEN);
-    expect(client.axios.get).toBeDefined();
-    expect(client.axios.post).toBeDefined();
-    expect(client.axios.put).toBeDefined();
-    expect(client.axios.delete).toBeDefined();
+    const client = new SlackOAuthClient({ accessToken: TOKEN });
 
-    client = new SlackOAuthClient({ accessToken: TOKEN });
     expect(client.axios.get).toBeDefined();
     expect(client.axios.post).toBeDefined();
     expect(client.axios.put).toBeDefined();
@@ -155,10 +118,8 @@ describe('#axios', () => {
 
 describe('#accessToken', () => {
   it('should return underlying access token', () => {
-    let client = new SlackOAuthClient(TOKEN);
-    expect(client.accessToken).toBe(TOKEN);
+    const client = new SlackOAuthClient({ accessToken: TOKEN });
 
-    client = new SlackOAuthClient({ accessToken: TOKEN });
     expect(client.accessToken).toBe(TOKEN);
   });
 });

--- a/packages/messaging-api-slack/src/__tests__/SlackOAuthClient.spec.ts
+++ b/packages/messaging-api-slack/src/__tests__/SlackOAuthClient.spec.ts
@@ -251,7 +251,9 @@ const camelcaseUser = {
 };
 
 const createMock = (): { client: SlackOAuthClient; mock: MockAdapter } => {
-  const client = new SlackOAuthClient(TOKEN);
+  const client = new SlackOAuthClient({
+    accessToken: TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-slack/src/__tests__/SlackWebhookClient-constructor.spec.ts
+++ b/packages/messaging-api-slack/src/__tests__/SlackWebhookClient-constructor.spec.ts
@@ -17,25 +17,6 @@ describe('connect', () => {
   });
 
   describe('create axios with webhook url', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      SlackWebhookClient.connect({
-        url: URL,
-      });
-
-      expect(axios.create).toBeCalledWith({
-        baseURL:
-          'https://hooks.slack.com/services/XXXXXXXX/YYYYYYYY/zzzzzZZZZZ',
-        headers: { 'Content-Type': 'application/json' },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -44,7 +25,7 @@ describe('connect', () => {
           },
         },
       });
-      SlackWebhookClient.connect(URL);
+      SlackWebhookClient.connect({ url: URL });
 
       expect(axios.create).toBeCalledWith({
         baseURL:
@@ -68,23 +49,6 @@ describe('constructor', () => {
   });
 
   describe('create axios with with webhook url', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      new SlackWebhookClient(URL); // eslint-disable-line no-new
-
-      expect(axios.create).toBeCalledWith({
-        baseURL:
-          'https://hooks.slack.com/services/XXXXXXXX/YYYYYYYY/zzzzzZZZZZ',
-        headers: { 'Content-Type': 'application/json' },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -109,7 +73,8 @@ describe('constructor', () => {
 
 describe('#axios', () => {
   it('should return underlying http client', () => {
-    const client = new SlackWebhookClient(URL);
+    const client = new SlackWebhookClient({ url: URL });
+
     expect(client.axios.get).toBeDefined();
     expect(client.axios.post).toBeDefined();
     expect(client.axios.put).toBeDefined();

--- a/packages/messaging-api-slack/src/__tests__/SlackWebhookClient.spec.ts
+++ b/packages/messaging-api-slack/src/__tests__/SlackWebhookClient.spec.ts
@@ -5,7 +5,9 @@ import SlackWebhookClient from '../SlackWebhookClient';
 const URL = 'https://hooks.slack.com/services/XXXXXXXX/YYYYYYYY/zzzzzZZZZZ';
 
 const createMock = (): { client: SlackWebhookClient; mock: MockAdapter } => {
-  const client = new SlackWebhookClient(URL);
+  const client = new SlackWebhookClient({
+    url: URL,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-telegram/package.json
+++ b/packages/messaging-api-telegram/package.json
@@ -16,6 +16,7 @@
     "axios-error": "file:../axios-error",
     "lodash": "^4.17.15",
     "messaging-api-common": "file:../messaging-api-common",
+    "ts-invariant": "^0.4.4",
     "warning": "^4.0.3"
   },
   "keywords": [

--- a/packages/messaging-api-telegram/src/TelegramClient.ts
+++ b/packages/messaging-api-telegram/src/TelegramClient.ts
@@ -1,6 +1,7 @@
 import AxiosError from 'axios-error';
 import axios, { AxiosInstance } from 'axios';
 import difference from 'lodash/difference';
+import invariant from 'ts-invariant';
 import isPlainObject from 'lodash/isPlainObject';
 import pick from 'lodash/pick';
 import warning from 'warning';
@@ -18,14 +19,12 @@ export default class TelegramClient {
   /**
    * @deprecated Use `new TelegramClient(...)` instead.
    */
-  static connect(
-    accessTokenOrConfig: string | Types.ClientConfig
-  ): TelegramClient {
+  static connect(config: Types.ClientConfig): TelegramClient {
     warning(
       false,
       '`TelegramClient.connect(...)` is deprecated. Use `new TelegramClient(...)` instead.'
     );
-    return new TelegramClient(accessTokenOrConfig);
+    return new TelegramClient(config);
   }
 
   /**
@@ -43,17 +42,15 @@ export default class TelegramClient {
    */
   private onRequest?: OnRequestFunction;
 
-  constructor(accessTokenOrConfig: string | Types.ClientConfig) {
-    let origin;
-    if (accessTokenOrConfig && typeof accessTokenOrConfig === 'object') {
-      const config = accessTokenOrConfig;
+  constructor(config: Types.ClientConfig) {
+    invariant(
+      typeof config !== 'string',
+      `TelegramClient: do not allow constructing client with ${config} string. Use object instead.`
+    );
 
-      this.accessToken = config.accessToken;
-      this.onRequest = config.onRequest;
-      origin = config.origin;
-    } else {
-      this.accessToken = accessTokenOrConfig;
-    }
+    this.accessToken = config.accessToken;
+    this.onRequest = config.onRequest;
+    const { origin } = config;
 
     this.axios = axios.create({
       baseURL: `${origin || 'https://api.telegram.org'}/bot${

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient-constructor.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient-constructor.spec.ts
@@ -5,7 +5,9 @@ import TelegramClient from '../TelegramClient';
 const ACCESS_TOKEN = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 
 const createMock = (): { client: TelegramClient; mock: MockAdapter } => {
-  const client = new TelegramClient(ACCESS_TOKEN);
+  const client = new TelegramClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };
@@ -23,25 +25,6 @@ describe('connect', () => {
   });
 
   describe('create axios with Telegram API', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      TelegramClient.connect(ACCESS_TOKEN);
-
-      expect(axios.create).toBeCalledWith({
-        baseURL:
-          'https://api.telegram.org/bot123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11/',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -98,25 +81,6 @@ describe('constructor', () => {
   });
 
   describe('create axios with Telegram API', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      new TelegramClient(ACCESS_TOKEN); // eslint-disable-line no-new
-
-      expect(axios.create).toBeCalledWith({
-        baseURL:
-          'https://api.telegram.org/bot123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11/',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -163,13 +127,8 @@ describe('constructor', () => {
 
 describe('#axios', () => {
   it('should return underlying http client', () => {
-    let client = new TelegramClient(ACCESS_TOKEN);
-    expect(client.axios.get).toBeDefined();
-    expect(client.axios.post).toBeDefined();
-    expect(client.axios.put).toBeDefined();
-    expect(client.axios.delete).toBeDefined();
+    const client = new TelegramClient({ accessToken: ACCESS_TOKEN });
 
-    client = new TelegramClient({ accessToken: ACCESS_TOKEN });
     expect(client.axios.get).toBeDefined();
     expect(client.axios.post).toBeDefined();
     expect(client.axios.put).toBeDefined();
@@ -191,10 +150,8 @@ describe('#axios', () => {
 
 describe('#accessToken', () => {
   it('should return underlying access token', () => {
-    let client = new TelegramClient(ACCESS_TOKEN);
-    expect(client.accessToken).toBe(ACCESS_TOKEN);
+    const client = new TelegramClient({ accessToken: ACCESS_TOKEN });
 
-    client = new TelegramClient({ accessToken: ACCESS_TOKEN });
     expect(client.accessToken).toBe(ACCESS_TOKEN);
   });
 });

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient-game.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient-game.spec.ts
@@ -5,7 +5,9 @@ import TelegramClient from '../TelegramClient';
 const ACCESS_TOKEN = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 
 const createMock = (): { client: TelegramClient; mock: MockAdapter } => {
-  const client = new TelegramClient(ACCESS_TOKEN);
+  const client = new TelegramClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient-group.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient-group.spec.ts
@@ -5,7 +5,9 @@ import TelegramClient from '../TelegramClient';
 const ACCESS_TOKEN = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 
 const createMock = (): { client: TelegramClient; mock: MockAdapter } => {
-  const client = new TelegramClient(ACCESS_TOKEN);
+  const client = new TelegramClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient-payment.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient-payment.spec.ts
@@ -5,7 +5,9 @@ import TelegramClient from '../TelegramClient';
 const ACCESS_TOKEN = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 
 const createMock = (): { client: TelegramClient; mock: MockAdapter } => {
-  const client = new TelegramClient(ACCESS_TOKEN);
+  const client = new TelegramClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient-send.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient-send.spec.ts
@@ -6,7 +6,9 @@ import { ChatAction, InputMediaType, ParseMode } from '../TelegramTypes';
 const ACCESS_TOKEN = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 
 const createMock = (): { client: TelegramClient; mock: MockAdapter } => {
-  const client = new TelegramClient(ACCESS_TOKEN);
+  const client = new TelegramClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient-stickerSet.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient-stickerSet.spec.ts
@@ -5,7 +5,9 @@ import TelegramClient from '../TelegramClient';
 const ACCESS_TOKEN = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 
 const createMock = (): { client: TelegramClient; mock: MockAdapter } => {
-  const client = new TelegramClient(ACCESS_TOKEN);
+  const client = new TelegramClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient-update.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient-update.spec.ts
@@ -6,7 +6,9 @@ import { ParseMode } from '../TelegramTypes';
 const ACCESS_TOKEN = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 
 const createMock = (): { client: TelegramClient; mock: MockAdapter } => {
-  const client = new TelegramClient(ACCESS_TOKEN);
+  const client = new TelegramClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.ts
+++ b/packages/messaging-api-telegram/src/__tests__/TelegramClient.spec.ts
@@ -5,7 +5,9 @@ import TelegramClient from '../TelegramClient';
 const ACCESS_TOKEN = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 
 const createMock = (): { client: TelegramClient; mock: MockAdapter } => {
-  const client = new TelegramClient(ACCESS_TOKEN);
+  const client = new TelegramClient({
+    accessToken: ACCESS_TOKEN,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };
@@ -225,6 +227,7 @@ describe('webhooks', () => {
 
       const res = await client.setWebhook('https://4a16faff.ngrok.io/', {
         certificate: 'qq',
+        // @ts-expect-error
         max_connections: 40,
         allowed_updates: [],
       });
@@ -633,12 +636,14 @@ describe('inline mode api', () => {
           {
             type: 'photo',
             id: 'UNIQUE_ID',
+            // @ts-expect-error
             photo_file_id: 'FILEID',
             title: 'PHOTO_TITLE',
           },
           {
             type: 'audio',
             id: 'UNIQUE_ID',
+            // @ts-expect-error
             audio_file_id: 'FILEID',
             caption: 'AUDIO_TITLE',
           },
@@ -718,6 +723,7 @@ describe('inline mode api', () => {
 
       const res = await client.answerCallbackQuery('CALLBACK_QUERY_ID', {
         text: 'text',
+        // @ts-expect-error
         show_alert: true,
         url: 'http://example.com/',
         cache_time: 1000,
@@ -891,6 +897,7 @@ describe('other api', () => {
         .reply(200, reply);
 
       const res = await client.stopMessageLiveLocation({
+        // @ts-expect-error
         chat_id: 427770117,
         message_id: 66,
       });
@@ -966,7 +973,7 @@ describe('_optionWithoutKeys', () => {
         b: '',
       },
     };
-    const client = new TelegramClient(ACCESS_TOKEN);
+    const client = new TelegramClient({ accessToken: ACCESS_TOKEN });
     const result = client._optionWithoutKeys(option, [
       'snakeCase',
       'camelCase',

--- a/packages/messaging-api-viber/package.json
+++ b/packages/messaging-api-viber/package.json
@@ -14,6 +14,7 @@
     "axios": "^0.19.2",
     "axios-error": "file:../axios-error",
     "messaging-api-common": "file:../messaging-api-common",
+    "ts-invariant": "^0.4.4",
     "warning": "^4.0.3"
   },
   "keywords": [

--- a/packages/messaging-api-viber/src/ViberClient.ts
+++ b/packages/messaging-api-viber/src/ViberClient.ts
@@ -1,5 +1,6 @@
 import AxiosError from 'axios-error';
 import axios, { AxiosInstance } from 'axios';
+import invariant from 'ts-invariant';
 import warning from 'warning';
 import {
   OnRequestFunction,
@@ -34,15 +35,12 @@ export default class ViberClient {
   /**
    * @deprecated Use `new ViberClient(...)` instead.
    */
-  static connect(
-    accessTokenOrConfig: string | Types.ClientConfig,
-    sender?: Types.Sender
-  ): ViberClient {
+  static connect(config: Types.ClientConfig): ViberClient {
     warning(
       false,
       '`ViberClient.connect(...)` is deprecated. Use `new ViberClient(...)` instead.'
     );
-    return new ViberClient(accessTokenOrConfig, sender);
+    return new ViberClient(config);
   }
 
   /**
@@ -65,23 +63,16 @@ export default class ViberClient {
    */
   private onRequest?: OnRequestFunction;
 
-  constructor(
-    accessTokenOrConfig: string | Types.ClientConfig,
-    sender?: Types.Sender
-  ) {
-    let origin;
-    if (accessTokenOrConfig && typeof accessTokenOrConfig === 'object') {
-      const config = accessTokenOrConfig;
+  constructor(config: Types.ClientConfig) {
+    invariant(
+      typeof config !== 'string',
+      `ViberClient: do not allow constructing client with ${config} string. Use object instead.`
+    );
 
-      this.accessToken = config.accessToken;
-      this.sender = config.sender;
-      this.onRequest = config.onRequest || onRequest;
-      origin = config.origin;
-    } else {
-      this.accessToken = accessTokenOrConfig;
-      this.sender = sender as Types.Sender;
-      this.onRequest = onRequest;
-    }
+    this.accessToken = config.accessToken;
+    this.sender = config.sender;
+    this.onRequest = config.onRequest || onRequest;
+    const { origin } = config;
 
     this.axios = axios.create({
       baseURL: `${origin || 'https://chatapi.viber.com'}/pa/`,

--- a/packages/messaging-api-viber/src/__tests__/ViberClient-broadcast.spec.ts
+++ b/packages/messaging-api-viber/src/__tests__/ViberClient-broadcast.spec.ts
@@ -16,7 +16,10 @@ const BROADCAST_LIST = [
 ];
 
 const createMock = (): { client: ViberClient; mock: MockAdapter } => {
-  const client = new ViberClient(AUTH_TOKEN, SENDER);
+  const client = new ViberClient({
+    accessToken: AUTH_TOKEN,
+    sender: SENDER,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-viber/src/__tests__/ViberClient-constructor.spec.ts
+++ b/packages/messaging-api-viber/src/__tests__/ViberClient-constructor.spec.ts
@@ -22,25 +22,6 @@ describe('connect', () => {
   });
 
   describe('create axios with Viber API', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      ViberClient.connect(AUTH_TOKEN, SENDER);
-
-      expect(axios.create).toBeCalledWith({
-        baseURL: 'https://chatapi.viber.com/pa/',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Viber-Auth-Token': AUTH_TOKEN,
-        },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -98,25 +79,6 @@ describe('constructor', () => {
   });
 
   describe('create axios with Viber API', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      new ViberClient(AUTH_TOKEN, SENDER); // eslint-disable-line no-new
-
-      expect(axios.create).toBeCalledWith({
-        baseURL: 'https://chatapi.viber.com/pa/',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Viber-Auth-Token': AUTH_TOKEN,
-        },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -164,13 +126,8 @@ describe('constructor', () => {
 
 describe('#axios', () => {
   it('should return underlying http client', () => {
-    let client = new ViberClient(AUTH_TOKEN, SENDER);
-    expect(client.axios.get).toBeDefined();
-    expect(client.axios.post).toBeDefined();
-    expect(client.axios.put).toBeDefined();
-    expect(client.axios.delete).toBeDefined();
+    const client = new ViberClient({ accessToken: AUTH_TOKEN, sender: SENDER });
 
-    client = new ViberClient({ accessToken: AUTH_TOKEN, sender: SENDER });
     expect(client.axios.get).toBeDefined();
     expect(client.axios.post).toBeDefined();
     expect(client.axios.put).toBeDefined();
@@ -180,10 +137,8 @@ describe('#axios', () => {
 
 describe('#accessToken', () => {
   it('should return underlying access token', () => {
-    let client = new ViberClient(AUTH_TOKEN, SENDER);
-    expect(client.accessToken).toBe(AUTH_TOKEN);
+    const client = new ViberClient({ accessToken: AUTH_TOKEN, sender: SENDER });
 
-    client = new ViberClient({ accessToken: AUTH_TOKEN, sender: SENDER });
     expect(client.accessToken).toBe(AUTH_TOKEN);
   });
 });

--- a/packages/messaging-api-viber/src/__tests__/ViberClient.spec.ts
+++ b/packages/messaging-api-viber/src/__tests__/ViberClient.spec.ts
@@ -13,7 +13,10 @@ const SENDER = {
 };
 
 const createMock = (): { client: ViberClient; mock: MockAdapter } => {
-  const client = new ViberClient(AUTH_TOKEN, SENDER);
+  const client = new ViberClient({
+    accessToken: AUTH_TOKEN,
+    sender: SENDER,
+  });
   const mock = new MockAdapter(client.axios);
   return { client, mock };
 };

--- a/packages/messaging-api-wechat/package.json
+++ b/packages/messaging-api-wechat/package.json
@@ -15,6 +15,7 @@
     "axios-error": "file:../axios-error",
     "form-data": "^3.0.0",
     "messaging-api-common": "file:../messaging-api-common",
+    "ts-invariant": "^0.4.4",
     "warning": "^4.0.3"
   },
   "keywords": [

--- a/packages/messaging-api-wechat/src/WechatClient.ts
+++ b/packages/messaging-api-wechat/src/WechatClient.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import AxiosError from 'axios-error';
 import FormData from 'form-data';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import invariant from 'ts-invariant';
 import warning from 'warning';
 import {
   OnRequestFunction,
@@ -29,15 +30,12 @@ export default class WechatClient {
   /**
    * @deprecated Use `new WechatClient(...)` instead.
    */
-  static connect(
-    appIdOrClientConfig: string | Types.ClientConfig,
-    appSecret: string
-  ): WechatClient {
+  static connect(config: Types.ClientConfig): WechatClient {
     warning(
       false,
       '`WechatClient.connect(...)` is deprecated. Use `new WechatClient(...)` instead.'
     );
-    return new WechatClient(appIdOrClientConfig, appSecret);
+    return new WechatClient(config);
   }
 
   /**
@@ -70,23 +68,16 @@ export default class WechatClient {
    */
   private tokenExpiresAt = 0;
 
-  constructor(
-    appIdOrClientConfig: string | Types.ClientConfig,
-    appSecret: string
-  ) {
-    let origin;
-    if (appIdOrClientConfig && typeof appIdOrClientConfig === 'object') {
-      const config = appIdOrClientConfig;
+  constructor(config: Types.ClientConfig) {
+    invariant(
+      typeof config !== 'string',
+      `WechatClient: do not allow constructing client with ${config} string. Use object instead.`
+    );
 
-      this.appId = config.appId;
-      this.appSecret = config.appSecret;
-      this.onRequest = config.onRequest || onRequest;
-      origin = config.origin;
-    } else {
-      this.appId = appIdOrClientConfig;
-      this.appSecret = appSecret;
-      this.onRequest = onRequest;
-    }
+    this.appId = config.appId;
+    this.appSecret = config.appSecret;
+    this.onRequest = config.onRequest || onRequest;
+    const { origin } = config;
 
     this.axios = axios.create({
       baseURL: `${origin || 'https://api.weixin.qq.com'}/cgi-bin/`,

--- a/packages/messaging-api-wechat/src/__tests__/WechatClient-constructor.spec.ts
+++ b/packages/messaging-api-wechat/src/__tests__/WechatClient-constructor.spec.ts
@@ -18,24 +18,6 @@ describe('connect', () => {
   });
 
   describe('create axios with WeChat API', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      WechatClient.connect(APP_ID, APP_SECRET);
-
-      expect(axios.create).toBeCalledWith({
-        baseURL: 'https://api.weixin.qq.com/cgi-bin/',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -91,24 +73,6 @@ describe('constructor', () => {
   });
 
   describe('create axios with WeChat API', () => {
-    it('with args', () => {
-      axios.create = jest.fn().mockReturnValue({
-        interceptors: {
-          request: {
-            use: jest.fn(),
-          },
-        },
-      });
-      new WechatClient(APP_ID, APP_SECRET); // eslint-disable-line no-new
-
-      expect(axios.create).toBeCalledWith({
-        baseURL: 'https://api.weixin.qq.com/cgi-bin/',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-    });
-
     it('with config', () => {
       axios.create = jest.fn().mockReturnValue({
         interceptors: {
@@ -154,13 +118,8 @@ describe('constructor', () => {
 
 describe('#axios', () => {
   it('should return underlying http client', () => {
-    let client = new WechatClient(APP_ID, APP_SECRET);
-    expect(client.axios.get).toBeDefined();
-    expect(client.axios.post).toBeDefined();
-    expect(client.axios.put).toBeDefined();
-    expect(client.axios.delete).toBeDefined();
+    const client = new WechatClient({ appId: APP_ID, appSecret: APP_SECRET });
 
-    client = new WechatClient({ appId: APP_ID, appSecret: APP_SECRET });
     expect(client.axios.get).toBeDefined();
     expect(client.axios.post).toBeDefined();
     expect(client.axios.put).toBeDefined();
@@ -170,10 +129,8 @@ describe('#axios', () => {
 
 describe('#accessToken', () => {
   it('should return underlying access token', () => {
-    let client = new WechatClient(APP_ID, APP_SECRET);
-    expect(typeof client.accessToken).toBe('string');
+    const client = new WechatClient({ appId: APP_ID, appSecret: APP_SECRET });
 
-    client = new WechatClient({ appId: APP_ID, appSecret: APP_SECRET });
     expect(typeof client.accessToken).toBe('string');
   });
 });

--- a/packages/messaging-api-wechat/src/__tests__/WechatClient.spec.ts
+++ b/packages/messaging-api-wechat/src/__tests__/WechatClient.spec.ts
@@ -10,7 +10,10 @@ const RECIPIENT_ID = '1QAZ2WSX';
 const ACCESS_TOKEN = '1234567890';
 
 const createMock = (): { client: WechatClient; mock: MockAdapter } => {
-  const client = new WechatClient(APP_ID, APP_SECRET);
+  const client = new WechatClient({
+    appId: APP_ID,
+    appSecret: APP_SECRET,
+  });
   const mock = new MockAdapter(client.axios);
 
   mock

--- a/yarn.lock
+++ b/yarn.lock
@@ -5607,7 +5607,7 @@ merge2@^1.2.3:
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
 "messaging-api-common@file:packages/messaging-api-common":
-  version "1.0.0-beta.26"
+  version "1.0.0-beta.29"
   dependencies:
     "@types/debug" "^4.1.5"
     "@types/lodash" "^4.14.156"
@@ -5622,17 +5622,17 @@ merge2@^1.2.3:
     url-join "^4.0.1"
 
 "messaging-api-messenger@file:packages/messaging-api-messenger":
-  version "1.0.0-beta.27"
+  version "1.0.0-beta.31"
   dependencies:
     "@types/append-query" "^2.0.0"
     "@types/lodash" "^4.14.156"
     "@types/warning" "^3.0.0"
     append-query "^2.1.0"
     axios "^0.19.2"
-    axios-error "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.0-beta.27-e476119d-5d8c-4cf3-bc5d-cef4d5bfef6c-1592965999892/node_modules/axios-error"
+    axios-error "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.0-beta.31-5d5bc6fc-b4bd-446f-8f02-8db4a16e4c39-1593593085628/node_modules/axios-error"
     form-data "^3.0.0"
     lodash "^4.17.15"
-    messaging-api-common "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.0-beta.27-e476119d-5d8c-4cf3-bc5d-cef4d5bfef6c-1592965999892/node_modules/messaging-api-common"
+    messaging-api-common "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.0-beta.31-5d5bc6fc-b4bd-446f-8f02-8db4a16e4c39-1593593085628/node_modules/messaging-api-common"
     ts-invariant "^0.4.4"
     warning "^4.0.3"
 


### PR DESCRIPTION
Remove support for constructing clients with string. This can help us simplify the code and provide readable document.