### PR TITLE
fix(MessengerClient): improve error message when receiving error html

### DIFF
--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -43,9 +43,11 @@ function handleError(
   }>
 ): never {
   if (err.response && err.response.data) {
-    const error = get(err, 'response.data.error', {});
-    const msg = `Messenger API - ${error.code} ${error.type} ${error.message}`;
-    throw new AxiosError(msg, err);
+    const error = get(err, 'response.data.error');
+    if (error) {
+      const msg = `Messenger API - ${error.code} ${error.type} ${error.message}`;
+      throw new AxiosError(msg, err);
+    }
   }
   throw new AxiosError(err.message, err);
 }


### PR DESCRIPTION
Avoid showing `Messenger API - undefined undefined undefined` when receiving error html.