### PR TITLE
feat(messenger): add includeHeaders support

### DIFF
--- a/packages/facebook-batch/src/FacebookBatchQueue.ts
+++ b/packages/facebook-batch/src/FacebookBatchQueue.ts
@@ -28,6 +28,8 @@ export default class FacebookBatchQueue {
 
   private retryTimes: number;
 
+  private includeHeaders: boolean;
+
   private timeout: NodeJS.Timeout;
 
   /**
@@ -58,6 +60,7 @@ export default class FacebookBatchQueue {
     this.delay = options.delay ?? 1000;
     this.shouldRetry = options.shouldRetry ?? alwaysTrue;
     this.retryTimes = options.retryTimes ?? 0;
+    this.includeHeaders = options.includeHeaders ?? true;
 
     this.timeout = setTimeout(() => this.flush(), this.delay);
   }
@@ -119,7 +122,10 @@ export default class FacebookBatchQueue {
 
     try {
       const responses = await this.client.sendBatch(
-        items.map((item) => item.request)
+        items.map((item) => item.request),
+        {
+          includeHeaders: this.includeHeaders,
+        }
       );
 
       items.forEach(({ request, resolve, reject, retry = 0 }, i) => {

--- a/packages/facebook-batch/src/types.ts
+++ b/packages/facebook-batch/src/types.ts
@@ -44,4 +44,5 @@ export type BatchConfig = {
   delay?: number;
   shouldRetry?: (err: BatchRequestErrorInfo) => boolean;
   retryTimes?: number;
+  includeHeaders?: boolean;
 };

--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -1196,7 +1196,10 @@ export default class MessengerClient {
    */
   sendBatch(
     batch: Types.BatchItem[],
-    { accessToken: customAccessToken }: Types.AccessTokenOptions = {}
+    {
+      includeHeaders = true,
+      accessToken: customAccessToken,
+    }: Types.AccessTokenOptions & { includeHeaders?: boolean } = {}
   ): Promise<
     {
       code: number;
@@ -1234,6 +1237,7 @@ export default class MessengerClient {
     return this.axios
       .post('/', {
         accessToken: customAccessToken || this.accessToken,
+        includeHeaders,
         batch: bodyEncodedbatch,
       })
       .then(

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-constructor.spec.ts
@@ -326,6 +326,7 @@ describe('appsecret proof', () => {
     );
     expect(JSON.parse(data)).toEqual({
       access_token: ACCESS_TOKEN,
+      include_headers: true,
       batch: [
         {
           method: 'POST',

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient-send.spec.ts
@@ -1146,6 +1146,9 @@ describe('send api', () => {
       const reply = [
         {
           code: 200,
+          headers: [
+            { name: 'Content-Type', value: 'text/javascript; charset=UTF-8' },
+          ],
           body:
             '{"recipient_id":"1QAZ2WSX","message_id":"mid.1489394984387:3dd22de509"}',
         },
@@ -1166,6 +1169,57 @@ describe('send api', () => {
       expect(url).toEqual('/');
       expect(JSON.parse(data)).toEqual({
         access_token: ACCESS_TOKEN,
+        include_headers: true,
+        batch: [
+          {
+            method: 'POST',
+            relative_url: 'me/messages',
+            body: `messaging_type=UPDATE&recipient=%7B%22id%22%3A%22${USER_ID}%22%7D&message=%7B%22text%22%3A%22Hello%22%7D`,
+          },
+        ],
+      });
+
+      expect(res).toEqual([
+        {
+          code: 200,
+          headers: [
+            { name: 'Content-Type', value: 'text/javascript; charset=UTF-8' },
+          ],
+          body: {
+            recipientId: USER_ID,
+            messageId: 'mid.1489394984387:3dd22de509',
+          },
+        },
+      ]);
+    });
+
+    it('support the includeHeaders option', async () => {
+      const { client, mock } = createMock();
+
+      const reply = [
+        {
+          code: 200,
+          body:
+            '{"recipient_id":"1QAZ2WSX","message_id":"mid.1489394984387:3dd22de509"}',
+        },
+      ];
+
+      const batch = [MessengerBatch.sendText(USER_ID, 'Hello')];
+
+      let url;
+      let data;
+      mock.onPost().reply((config) => {
+        url = config.url;
+        data = config.data;
+        return [200, reply];
+      });
+
+      const res = await client.sendBatch(batch, { includeHeaders: false });
+
+      expect(url).toEqual('/');
+      expect(JSON.parse(data)).toEqual({
+        access_token: ACCESS_TOKEN,
+        include_headers: false,
         batch: [
           {
             method: 'POST',
@@ -1192,6 +1246,9 @@ describe('send api', () => {
       const reply = [
         {
           code: 200,
+          headers: [
+            { name: 'Content-Type', value: 'text/javascript; charset=UTF-8' },
+          ],
           body: '{"data":[{"thread_owner":{"app_id":"501514720355337"}}]}',
         },
       ];
@@ -1211,6 +1268,7 @@ describe('send api', () => {
       expect(url).toEqual(`/`);
       expect(JSON.parse(data)).toEqual({
         access_token: ACCESS_TOKEN,
+        include_headers: true,
         batch: [
           {
             method: 'GET',
@@ -1222,6 +1280,9 @@ describe('send api', () => {
       expect(res).toEqual([
         {
           code: 200,
+          headers: [
+            { name: 'Content-Type', value: 'text/javascript; charset=UTF-8' },
+          ],
           body: { appId: '501514720355337' },
         },
       ]);


### PR DESCRIPTION
Ref: https://developers.facebook.com/docs/graph-api/making-multiple-requests/

In `MessengerClient`:

```js
client.sendBatch([/* ... */], { includeHeaders: false });
```

In `FacebookBatchQueue`:

```js
new FacebookBatchQueue(/* ... */, { includeHeaders: false });
```
