### PR TITLE
fix(LineClient): make channelSecret optional

### DIFF
--- a/packages/messaging-api-line/src/LineClient.ts
+++ b/packages/messaging-api-line/src/LineClient.ts
@@ -69,7 +69,7 @@ export default class LineClient {
   /**
    * The channel secret used by the client
    */
-  readonly channelSecret: string;
+  readonly channelSecret: string | undefined;
 
   /**
    * The callback to be called when receiving requests.
@@ -83,7 +83,6 @@ export default class LineClient {
    * ```ts
    * new LineClient({
    *   accessToken: ACCESS_TOKEN,
-   *   channelSecret: CHANNEL_SECRET
    * })
    * ```
    *

--- a/packages/messaging-api-line/src/LineTypes.ts
+++ b/packages/messaging-api-line/src/LineTypes.ts
@@ -2,7 +2,7 @@ import { OnRequestFunction } from 'messaging-api-common';
 
 export type ClientConfig = {
   accessToken: string;
-  channelSecret: string;
+  channelSecret?: string;
   origin?: string;
   dataOrigin?: string;
   onRequest?: OnRequestFunction;


### PR DESCRIPTION
`channelSecret` is not required in client operations, so we should make it optional.