### PR TITLE
deprecated: remove getMessageTags in messenger api

### DIFF
--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -15,7 +15,6 @@
     - [Quick Replies](#quick-replies)
     - [Sender Actions](#sender-actions)
     - [Attachment Upload API](#attachment-upload-api)
-    - [Tags](#tags)
     - [Message Batching](#message-batching)
   - [Broadcast API](#broadcast-api)
     - [Targeting Broadcast Messages](#targeting-broadcast-messages)
@@ -1380,66 +1379,6 @@ Or using buffer:
 client.uploadFile(buffer, {
   is_reusable: true,
   filename: 'file.pdf',
-});
-```
-
-<br />
-
-<a id="tags" />
-
-### Tags - [Official Docs](https://developers.facebook.com/docs/messenger-platform/send-api-reference/tags/)
-
-## `getMessageTags`
-
-Getting tags list via an API.
-
-Example:
-
-```js
-client.getMessageTags().then((tags) => {
-  console.log(tags);
-  // [
-  //   {
-  //     tag: 'SHIPPING_UPDATE',
-  //     description:
-  //       'The shipping_update tag may only be used to provide a shipping status notification for a product that has already been purchased. For example, when the product is shipped, in-transit, delivered, or delayed. This tag cannot be used for use cases beyond those listed above or for promotional content (ex: daily deals, coupons and discounts, or sale announcements).',
-  //   },
-  //   {
-  //     tag: 'RESERVATION_UPDATE',
-  //     description:
-  //       'The reservation_update tag may only be used to confirm updates to an existing reservation. For example, when there is a change in itinerary, location, or a cancellation (such as when a hotel booking is canceled, a car rental pick-up time changes, or a room upgrade is confirmed). This tag cannot be used for use cases beyond those listed above or for promotional content (ex: daily deals, coupons and discounts, or sale announcements).',
-  //   },
-  //   {
-  //     tag: 'ISSUE_RESOLUTION',
-  //     description:
-  //       'The issue_resolution tag may only be used to respond to a customer service issue surfaced in a Messenger conversation after a transaction has taken place. This tag is intended for use cases where the business requires more than 24 hours to resolve an issue and needs to give someone a status update and/or gather additional information. This tag cannot be used for use cases beyond those listed above or for promotional content (ex: daily deals, coupons and discounts, or sale announcements, nor can businesses use the tag to proactively message people to solicit feedback).',
-  //   },
-  //   {
-  //     tag: 'APPOINTMENT_UPDATE',
-  //     description:
-  //       'The appointment_update tag may only be used to provide updates about an existing appointment. For example, when there is a change in time, a location update or a cancellation (such as when a spa treatment is canceled, a real estate agent needs to meet you at a new location or a dental office proposes a new appointment time). This tag cannot be used for use cases beyond those listed above or for promotional content (ex: daily deals, coupons and discounts, or sale announcements).',
-  //   },
-  //   {
-  //     tag: 'GAME_EVENT',
-  //     description:
-  //       'The game_event tag may only be used to provide an update on user progression, a global event in a game or a live sporting event. For example, when a person’s crops are ready to be collected, their building is finished, their daily tournament is about to start or their favorite soccer team is about to play. This tag cannot be used for use cases beyond those listed above or for promotional content (ex: daily deals, coupons and discounts, or sale announcements).',
-  //   },
-  //   {
-  //     tag: 'TRANSPORTATION_UPDATE',
-  //     description:
-  //       'The transportation_update tag may only be used to confirm updates to an existing reservation. For example, when there is a change in status of any flight, train or ferry reservation (such as “ride canceled”, “trip started” or “ferry arrived”). This tag cannot be used for use cases beyond those listed above or for promotional content (ex: daily deals, coupons and discounts, or sale announcements).',
-  //   },
-  //   {
-  //     tag: 'FEATURE_FUNCTIONALITY_UPDATE',
-  //     description:
-  //       'The feature_functionality_update tag may only be used to provide an update on new features or functionality that become available in a bot. For example, announcing the ability to talk to a live agent in a bot, or that the bot has a new skill. This tag cannot be used for use cases beyond those listed above or for promotional content (ex: daily deals, coupons and discounts, or sale announcements).',
-  //   },
-  //   {
-  //     tag: 'TICKET_UPDATE',
-  //     description:
-  //       'The ticket_update tag may only be used to provide updates pertaining to an event for which a person already has a ticket. For example, when there is a change in time, a location update or a cancellation (such as when a concert is canceled, the venue has changed or a refund opportunity is available). This tag cannot be used for use cases beyond those listed above or for promotional content (ex: daily deals, coupons and discounts, or sale announcements).',
-  //   },
-  // ]
 });
 ```
 

--- a/packages/messaging-api-messenger/src/MessengerClient.ts
+++ b/packages/messaging-api-messenger/src/MessengerClient.ts
@@ -678,19 +678,6 @@ export default class MessengerClient {
   }
 
   /**
-   * Message tags
-   *
-   * https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags
-   */
-  getMessageTags(): Promise<Types.MessageTagResponse> {
-    return this.axios
-      .get<{ data: Types.MessageTagResponse }>(
-        `/page_message_tags?access_token=${this.accessToken}`
-      )
-      .then((res) => res.data.data, handleError);
-  }
-
-  /**
    * Send API
    *
    * https://developers.facebook.com/docs/messenger-platform/reference/send-api

--- a/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.ts
+++ b/packages/messaging-api-messenger/src/__tests__/MessengerClient.spec.ts
@@ -430,52 +430,6 @@ describe('user profile', () => {
   });
 });
 
-describe('message tags', () => {
-  describe('#getMessageTags', () => {
-    it('should response data of message tags', async () => {
-      const { client, mock } = createMock();
-
-      const reply = {
-        data: [
-          {
-            tag: 'POST_PURCHASE_UPDATE',
-            description:
-              'Notify the message recipient of an update on an existing transaction.',
-          },
-          {
-            tag: 'ACCOUNT_UPDATE',
-            description:
-              'Notify the message recipient of a change to their account settings.',
-          },
-        ],
-      };
-
-      let url;
-      mock.onGet().reply((config) => {
-        url = config.url;
-        return [200, reply];
-      });
-
-      const res = await client.getMessageTags();
-
-      expect(url).toEqual(`/page_message_tags?access_token=${ACCESS_TOKEN}`);
-
-      expect(res).toEqual([
-        {
-          tag: 'POST_PURCHASE_UPDATE',
-          description:
-            'Notify the message recipient of an update on an existing transaction.',
-        },
-        {
-          tag: 'ACCOUNT_UPDATE',
-          description:
-            'Notify the message recipient of a change to their account settings.',
-        },
-      ]);
-    });
-  });
-});
-
 describe('upload api', () => {
   describe('#uploadAttachment', () => {
     it('should call messages api to upload attachment', async () => {


### PR DESCRIPTION
<img width="1034" alt="截圖 2020-08-14 下午3 10 48" src="https://user-images.githubusercontent.com/3382565/90223315-68751c00-de40-11ea-9dfa-e88d6d14a5e6.png">

ref: https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags#retrieving