### PR TITLE
fix(messaging-api-messenger): type TemplateElement should allow optional attributes

### DIFF
--- a/packages/messaging-api-messenger/src/MessengerTypes.ts
+++ b/packages/messaging-api-messenger/src/MessengerTypes.ts
@@ -209,16 +209,16 @@ export type MenuItem = TemplateButton;
 
 export type TemplateElement = {
   title: string;
-  imageUrl: string;
-  subtitle: string;
-  defaultAction: {
+  imageUrl?: string;
+  subtitle?: string;
+  defaultAction?: {
     type: string;
     url: string;
-    messengerExtensions: boolean;
-    webviewHeightRatio: string;
-    fallbackUrl: string;
+    messengerExtensions?: boolean;
+    webviewHeightRatio?: string;
+    fallbackUrl?: string;
   };
-  buttons: TemplateButton[];
+  buttons?: TemplateButton[];
 };
 
 export type MediaElement = {


### PR DESCRIPTION
According to the following document:

<img width="856" alt="截圖 2021-04-15 下午3 03 09" src="https://user-images.githubusercontent.com/3382565/114827796-b5f4bf00-9dfb-11eb-80df-f20559e7ba16.png">
