### PR TITLE
fix: use built-in monorepo support in typedoc 0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "testonly": "jest",
     "testonly:cov": "jest --coverage",
     "testonly:watch": "jest --watch",
-    "typedoc": "typedoc ./packages",
+    "typedoc": "typedoc --entryPointStrategy packages .",
     "watch": "tsc --build tsconfig.build.json --watch"
   },
   "workspaces": [
@@ -55,7 +55,6 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.2.0",
     "typedoc": "^0.22.3",
-    "typedoc-plugin-lerna-packages": "github:marcj/typedoc-plugin-lerna-packages#f5d8f7d",
     "typescript": "^4.4.3"
   },
   "engines": {

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,5 +1,4 @@
 module.exports = {
-  mode: 'modules',
   out: 'docs',
   exclude: [
     '**/node_modules/**',
@@ -9,8 +8,6 @@ module.exports = {
   ],
   name: 'messaging-apis',
   excludePrivate: true,
-  excludeNotExported: true,
   excludeExternals: true,
-  esModuleInterop: true,
   includeVersion: true,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5780,10 +5780,10 @@ merge2@^1.2.3, merge2@^1.3.0:
     "@types/warning" "^3.0.0"
     append-query "^2.1.0"
     axios "^0.21.1"
-    axios-error "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.6-3829411b-e3c2-4a04-aa99-38986cf8e212-1631639825044/node_modules/axios-error"
+    axios-error "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.6-2d307e69-cb1f-4737-bf6f-76f24d00f6a9-1633320998216/node_modules/axios-error"
     form-data "^3.0.0"
     lodash "^4.17.15"
-    messaging-api-common "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.6-3829411b-e3c2-4a04-aa99-38986cf8e212-1631639825044/node_modules/messaging-api-common"
+    messaging-api-common "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.0.6-2d307e69-cb1f-4737-bf6f-76f24d00f6a9-1633320998216/node_modules/messaging-api-common"
     ts-invariant "^0.4.4"
     warning "^4.0.3"
 
@@ -8203,10 +8203,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-"typedoc-plugin-lerna-packages@github:marcj/typedoc-plugin-lerna-packages#f5d8f7d":
-  version "0.3.1"
-  resolved "https://codeload.github.com/marcj/typedoc-plugin-lerna-packages/tar.gz/f5d8f7d0958a00c9f7976701bb9273c939764b49"
 
 typedoc@^0.22.3:
   version "0.22.3"


### PR DESCRIPTION
typedoc now supports monorepos and workspaces:

https://github.com/TypeStrong/typedoc#monorepos--workspaces