### PR TITLE
fix: improve types for case converter

### DIFF
--- a/packages/messaging-api-common/package.json
+++ b/packages/messaging-api-common/package.json
@@ -1,12 +1,12 @@
 {
   "name": "messaging-api-common",
+  "version": "1.0.4",
   "description": "Helpers for common usages in Messaging API clients",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/Yoctol/messaging-apis.git"
   },
-  "version": "1.0.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
@@ -20,6 +20,7 @@
     "map-obj": "^4.1.0",
     "pascal-case": "^3.1.1",
     "snake-case": "^3.0.3",
+    "type-fest": "1.4.0",
     "url-join": "^4.0.1"
   },
   "keywords": [

--- a/packages/messaging-api-common/src/case.ts
+++ b/packages/messaging-api-common/src/case.ts
@@ -2,7 +2,18 @@ import mapObject from 'map-obj';
 import { camelCase } from 'camel-case';
 import { pascalCase } from 'pascal-case';
 import { snakeCase } from 'snake-case';
-import type { Options } from 'map-obj';
+import type {
+  CamelCase,
+  CamelCasedProperties,
+  CamelCasedPropertiesDeep,
+  PascalCase,
+  PascalCasedProperties,
+  PascalCasedPropertiesDeep,
+  SnakeCase,
+  SnakeCasedProperties,
+  SnakeCasedPropertiesDeep,
+} from 'type-fest';
+import type { Options as MapOptions } from 'map-obj';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type PlainObject = Record<string, any>;
@@ -30,13 +41,13 @@ function splitLastChar(key: string): string {
  * //=> 'foo_bar'
  * ```
  */
-function snakecase(text: string): string {
+function snakecase<T extends string>(text: T): SnakeCase<T> {
   const matches = text.match(/\d+/g);
   if (!matches) {
-    return snakeCase(text);
+    return snakeCase(text) as SnakeCase<T>;
   }
 
-  let modifiedStr = text;
+  let modifiedStr: string = text;
   for (let i = 0; i < matches.length; i++) {
     const match = matches[i];
     const mathIndex = modifiedStr.indexOf(match);
@@ -46,7 +57,7 @@ function snakecase(text: string): string {
     )}`;
   }
 
-  return snakeCase(modifiedStr);
+  return snakeCase(modifiedStr) as SnakeCase<T>;
 }
 
 /**
@@ -62,13 +73,19 @@ function snakecase(text: string): string {
  * //=> { 'foo_bar': true }
  * ```
  */
-function snakecaseKeys(obj: PlainObject, options: Options = {}): PlainObject {
+function snakecaseKeys<T extends PlainObject, O extends MapOptions>(
+  obj: T,
+  options?: O
+): O['deep'] extends true
+  ? SnakeCasedPropertiesDeep<T>
+  : SnakeCasedProperties<T> {
   return mapObject(
     obj,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (key: string, val: any) => [snakecase(key), val],
+    (key, val) => [snakecase(key as string), val],
     options
-  );
+  ) as O['deep'] extends true
+    ? SnakeCasedPropertiesDeep<T>
+    : SnakeCasedProperties<T>;
 }
 
 /**
@@ -83,7 +100,9 @@ function snakecaseKeys(obj: PlainObject, options: Options = {}): PlainObject {
  * //=> { 'foo_bar': { 'bar_foo': true } }
  * ```
  */
-function snakecaseKeysDeep(obj: PlainObject): PlainObject {
+function snakecaseKeysDeep<T extends PlainObject>(
+  obj: T
+): SnakeCasedPropertiesDeep<T> {
   return snakecaseKeys(obj, { deep: true });
 }
 
@@ -99,7 +118,7 @@ function snakecaseKeysDeep(obj: PlainObject): PlainObject {
  * //=> 'fooBar'
  * ```
  */
-function camelcase(text: string): string {
+function camelcase<T extends string>(text: T): CamelCase<T> {
   const parts = text.split('_');
   const modifiedStr = parts.reduce((acc, part) => {
     if (acc === '') return part;
@@ -108,7 +127,7 @@ function camelcase(text: string): string {
     }
     return `${acc}_${part}`;
   }, '');
-  return camelCase(modifiedStr);
+  return camelCase(modifiedStr) as CamelCase<T>;
 }
 
 /**
@@ -124,13 +143,19 @@ function camelcase(text: string): string {
  * //=> { 'fooBar': true }
  * ```
  */
-function camelcaseKeys(obj: PlainObject, options: Options = {}): PlainObject {
+function camelcaseKeys<T extends PlainObject, O extends MapOptions>(
+  obj: T,
+  options?: O
+): O['deep'] extends true
+  ? CamelCasedPropertiesDeep<T>
+  : CamelCasedProperties<T> {
   return mapObject(
     obj,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (key: string, val: any) => [camelcase(key), val],
+    (key, val) => [camelcase(key as string), val],
     options
-  );
+  ) as O['deep'] extends true
+    ? CamelCasedPropertiesDeep<T>
+    : CamelCasedProperties<T>;
 }
 
 /**
@@ -145,7 +170,9 @@ function camelcaseKeys(obj: PlainObject, options: Options = {}): PlainObject {
  * //=> { 'fooBar': { 'barFoo': true } }
  * ```
  */
-function camelcaseKeysDeep(obj: PlainObject): PlainObject {
+function camelcaseKeysDeep<T extends PlainObject>(
+  obj: T
+): CamelCasedPropertiesDeep<T> {
   return camelcaseKeys(obj, { deep: true });
 }
 
@@ -161,8 +188,10 @@ function camelcaseKeysDeep(obj: PlainObject): PlainObject {
  * //=> 'FooBar'
  * ```
  */
-function pascalcase(str: string): string {
-  return pascalCase(isLastCharNumber(str) ? splitLastChar(str) : str);
+function pascalcase<T extends string>(str: T): PascalCase<T> {
+  return pascalCase(
+    isLastCharNumber(str) ? splitLastChar(str) : str
+  ) as PascalCase<T>;
 }
 
 /**
@@ -178,13 +207,19 @@ function pascalcase(str: string): string {
  * //=> { 'FooBar': true }
  * ```
  */
-function pascalcaseKeys(obj: PlainObject, options: Options = {}): PlainObject {
+function pascalcaseKeys<T extends PlainObject, O extends MapOptions>(
+  obj: T,
+  options?: O
+): O['deep'] extends true
+  ? PascalCasedPropertiesDeep<T>
+  : PascalCasedProperties<T> {
   return mapObject(
     obj,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (key: string, val: any) => [pascalcase(key), val],
+    (key, val) => [pascalcase(key as string), val],
     options
-  );
+  ) as O['deep'] extends true
+    ? PascalCasedPropertiesDeep<T>
+    : PascalCasedProperties<T>;
 }
 
 /**
@@ -199,7 +234,9 @@ function pascalcaseKeys(obj: PlainObject, options: Options = {}): PlainObject {
  * //=> { 'FooBar': { 'BarFoo': true } }
  * ```
  */
-function pascalcaseKeysDeep(obj: PlainObject): PlainObject {
+function pascalcaseKeysDeep<T extends PlainObject>(
+  obj: T
+): PascalCasedPropertiesDeep<T> {
   return pascalcaseKeys(obj, { deep: true });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5556,10 +5556,10 @@ merge2@^1.3.0:
     "@types/warning" "^3.0.0"
     append-query "^2.1.0"
     axios "^0.21.1"
-    axios-error "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.1.0-507af1fc-bd10-4188-b759-9cb4b007841b-1633441314031/node_modules/axios-error"
+    axios-error "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.1.0-dd4c6fb5-d902-468b-b52a-141c496df733-1633444914814/node_modules/axios-error"
     form-data "^3.0.0"
     lodash "^4.17.15"
-    messaging-api-common "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.1.0-507af1fc-bd10-4188-b759-9cb4b007841b-1633441314031/node_modules/messaging-api-common"
+    messaging-api-common "file:../../../Library/Caches/Yarn/v6/npm-messaging-api-messenger-1.1.0-dd4c6fb5-d902-468b-b52a-141c496df733-1633444914814/node_modules/messaging-api-common"
     ts-invariant "^0.4.4"
     warning "^4.0.3"
 
@@ -7885,6 +7885,11 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
+type-fest@1.4.0, type-fest@^1.2.2, type-fest@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
 type-fest@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.15.1.tgz#d2c4e73d3e4a53cf1a906396dd460a1c5178ca00"
@@ -7919,11 +7924,6 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-type-fest@^1.2.2, type-fest@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
-  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
There're some edge cases that didn't cover in this PR:

- has2fa -> has_2fa
- image1024 -> image_1024